### PR TITLE
feat: 타마고의 편지 도메인 모델링 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ out/
 ### Kotlin ###
 .kotlin
 
+### Json ###
+firebase-service-account.json

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
     id("io.spring.dependency-management")
 }
 
+val kotlinJdslVersion = "3.7.1"
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -13,10 +15,15 @@ dependencies {
 
     implementation("org.springframework.modulith:spring-modulith-starter-core")
 
+    // Kotlin JDSL
+    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:$kotlinJdslVersion")
+    implementation("com.linecorp.kotlin-jdsl:jpql-render:$kotlinJdslVersion")
+    implementation("com.linecorp.kotlin-jdsl:spring-data-jpa-support:$kotlinJdslVersion")
+
     runtimeOnly("com.mysql:mysql-connector-j")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 
-    implementation ("io.jsonwebtoken:jjwt:0.12.6")
+    implementation("io.jsonwebtoken:jjwt:0.12.6")
 }
 
 tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {

--- a/core/src/main/kotlin/tamago/server/core/letter/LetterCommandUseCase.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/LetterCommandUseCase.kt
@@ -1,0 +1,7 @@
+package tamago.server.core.letter
+
+import tamago.server.core.letter.domain.aggregate.ReceivedLetter
+
+interface LetterCommandUseCase {
+    fun markAsRead(receivedLetter: ReceivedLetter)
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/LetterCommandUseCase.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/LetterCommandUseCase.kt
@@ -1,7 +1,10 @@
 package tamago.server.core.letter
 
+import tamago.server.core.letter.domain.aggregate.Letter
 import tamago.server.core.letter.domain.aggregate.ReceivedLetter
+import tamago.server.core.letter.domain.enum.LetterMood
 
 interface LetterCommandUseCase {
     fun markAsRead(receivedLetter: ReceivedLetter)
+    fun createTemplate(title: String, content: String, mood: LetterMood): Letter
 }

--- a/core/src/main/kotlin/tamago/server/core/letter/LetterFacade.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/LetterFacade.kt
@@ -1,0 +1,17 @@
+package tamago.server.core.letter
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import tamago.server.core.letter.domain.vo.ReceivedLetterId
+
+@Component
+class LetterFacade(
+    private val letterQueryUseCase: LetterQueryUseCase,
+    private val letterCommandUseCase: LetterCommandUseCase,
+) {
+    @Transactional
+    fun markAsRead(receivedLetterId: ReceivedLetterId) {
+        val receivedLetter = letterQueryUseCase.get(receivedLetterId)
+        letterCommandUseCase.markAsRead(receivedLetter)
+    }
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/LetterFacade.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/LetterFacade.kt
@@ -2,16 +2,20 @@ package tamago.server.core.letter
 
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import tamago.server.core.letter.application.validator.LetterValidator
 import tamago.server.core.letter.domain.vo.ReceivedLetterId
+import tamago.server.core.user.domain.aggregate.User
 
 @Component
 class LetterFacade(
     private val letterQueryUseCase: LetterQueryUseCase,
     private val letterCommandUseCase: LetterCommandUseCase,
+    private val letterValidator: LetterValidator,
 ) {
     @Transactional
-    fun markAsRead(receivedLetterId: ReceivedLetterId) {
+    fun markAsRead(user: User, receivedLetterId: ReceivedLetterId) {
         val receivedLetter = letterQueryUseCase.get(receivedLetterId)
+        letterValidator.validateOwner(user.id!!, receivedLetter)
         letterCommandUseCase.markAsRead(receivedLetter)
     }
 }

--- a/core/src/main/kotlin/tamago/server/core/letter/LetterQueryUseCase.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/LetterQueryUseCase.kt
@@ -1,0 +1,11 @@
+package tamago.server.core.letter
+
+import tamago.server.core.letter.domain.aggregate.ReceivedLetter
+import tamago.server.core.letter.domain.port.inbound.query.LetterInboxDto
+import tamago.server.core.letter.domain.vo.ReceivedLetterId
+import tamago.server.core.user.domain.vo.UserId
+
+interface LetterQueryUseCase {
+    fun getLatestReceivedLetter(userId: UserId): LetterInboxDto?
+    fun get(id: ReceivedLetterId): ReceivedLetter
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/application/exception/LetterAccessDeniedException.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/application/exception/LetterAccessDeniedException.kt
@@ -1,0 +1,7 @@
+package tamago.server.core.letter.application.exception
+
+import tamago.server.core.common.exception.BusinessException
+
+class LetterAccessDeniedException : BusinessException(
+    LetterExceptionCode.LETTER_ACCESS_DENIED,
+)

--- a/core/src/main/kotlin/tamago/server/core/letter/application/exception/LetterExceptionCode.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/application/exception/LetterExceptionCode.kt
@@ -9,6 +9,7 @@ enum class LetterExceptionCode(
     @JvmField val message: String,
 ) : ExceptionCode {
     RECEIVED_LETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "LETTER_4040", "받은 편지를 찾을 수 없습니다."),
+    LETTER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "LETTER_4030", "해당 편지에 접근 권한이 없습니다."),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/core/src/main/kotlin/tamago/server/core/letter/application/exception/LetterExceptionCode.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/application/exception/LetterExceptionCode.kt
@@ -1,0 +1,19 @@
+package tamago.server.core.letter.application.exception
+
+import org.springframework.http.HttpStatus
+import tamago.server.core.common.exception.ExceptionCode
+
+enum class LetterExceptionCode(
+    @JvmField val status: HttpStatus,
+    @JvmField val code: String,
+    @JvmField val message: String,
+) : ExceptionCode {
+    RECEIVED_LETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "LETTER_4040", "받은 편지를 찾을 수 없습니다."),
+    ;
+
+    override fun getStatus(): HttpStatus = status
+
+    override fun getCode(): String = code
+
+    override fun getMessage(): String = message
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/application/exception/ReceivedLetterNotFoundException.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/application/exception/ReceivedLetterNotFoundException.kt
@@ -1,0 +1,7 @@
+package tamago.server.core.letter.application.exception
+
+import tamago.server.core.common.exception.BusinessException
+
+class ReceivedLetterNotFoundException : BusinessException(
+    LetterExceptionCode.RECEIVED_LETTER_NOT_FOUND,
+)

--- a/core/src/main/kotlin/tamago/server/core/letter/application/service/LetterCommandService.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/application/service/LetterCommandService.kt
@@ -1,0 +1,17 @@
+package tamago.server.core.letter.application.service
+
+import org.springframework.stereotype.Service
+import tamago.server.core.letter.LetterCommandUseCase
+import tamago.server.core.letter.domain.aggregate.ReceivedLetter
+import tamago.server.core.letter.domain.port.outbound.ReceivedLetterPersistencePort
+
+@Service
+class LetterCommandService(
+    private val receivedLetterPersistencePort: ReceivedLetterPersistencePort,
+) : LetterCommandUseCase {
+
+    override fun markAsRead(receivedLetter: ReceivedLetter) {
+        receivedLetter.markAsRead()
+        receivedLetterPersistencePort.save(receivedLetter)
+    }
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/application/service/LetterCommandService.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/application/service/LetterCommandService.kt
@@ -1,17 +1,33 @@
 package tamago.server.core.letter.application.service
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import tamago.server.core.letter.LetterCommandUseCase
+import tamago.server.core.letter.domain.aggregate.Letter
 import tamago.server.core.letter.domain.aggregate.ReceivedLetter
+import tamago.server.core.letter.domain.enum.LetterMood
+import tamago.server.core.letter.domain.port.outbound.LetterPersistencePort
 import tamago.server.core.letter.domain.port.outbound.ReceivedLetterPersistencePort
 
 @Service
 class LetterCommandService(
+    private val letterPersistencePort: LetterPersistencePort,
     private val receivedLetterPersistencePort: ReceivedLetterPersistencePort,
 ) : LetterCommandUseCase {
 
+    @Transactional
     override fun markAsRead(receivedLetter: ReceivedLetter) {
         receivedLetter.markAsRead()
         receivedLetterPersistencePort.save(receivedLetter)
+    }
+
+    @Transactional
+    override fun createTemplate(
+        title: String,
+        content: String,
+        mood: LetterMood
+    ): Letter {
+        val letter = Letter.create(title, content, mood)
+        return letterPersistencePort.save(letter)
     }
 }

--- a/core/src/main/kotlin/tamago/server/core/letter/application/service/LetterQueryService.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/application/service/LetterQueryService.kt
@@ -1,0 +1,36 @@
+package tamago.server.core.letter.application.service
+
+import org.springframework.stereotype.Service
+import tamago.server.core.letter.LetterQueryUseCase
+import tamago.server.core.letter.application.exception.ReceivedLetterNotFoundException
+import tamago.server.core.letter.domain.aggregate.ReceivedLetter
+import tamago.server.core.letter.domain.port.inbound.query.LetterInboxDto
+import tamago.server.core.letter.domain.port.outbound.LetterPersistencePort
+import tamago.server.core.letter.domain.port.outbound.ReceivedLetterPersistencePort
+import tamago.server.core.letter.domain.vo.ReceivedLetterId
+import tamago.server.core.user.domain.vo.UserId
+
+@Service
+class LetterQueryService(
+    private val letterPersistencePort: LetterPersistencePort,
+    private val receivedLetterPersistencePort: ReceivedLetterPersistencePort,
+) : LetterQueryUseCase {
+
+    override fun getLatestReceivedLetter(userId: UserId): LetterInboxDto? {
+        val query = letterPersistencePort.findTopReceivedLetterByUserId(userId)
+
+        return query?.let {
+            LetterInboxDto(
+                id = it.id,
+                title = it.title,
+                content = it.content,
+                readStatus = it.readStatus,
+            )
+        }
+    }
+
+    override fun get(id: ReceivedLetterId): ReceivedLetter {
+        return receivedLetterPersistencePort.findById(id)
+            ?: throw ReceivedLetterNotFoundException()
+    }
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/application/validator/LetterValidator.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/application/validator/LetterValidator.kt
@@ -1,0 +1,15 @@
+package tamago.server.core.letter.application.validator
+
+import org.springframework.stereotype.Component
+import tamago.server.core.letter.application.exception.LetterAccessDeniedException
+import tamago.server.core.letter.domain.aggregate.ReceivedLetter
+import tamago.server.core.user.domain.vo.UserId
+
+@Component
+class LetterValidator {
+    fun validateOwner(userId: UserId, receivedLetter: ReceivedLetter) {
+        if (!receivedLetter.isOwnedBy(userId)) {
+            throw LetterAccessDeniedException()
+        }
+    }
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/aggregate/Letter.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/aggregate/Letter.kt
@@ -1,5 +1,6 @@
 package tamago.server.core.letter.domain.aggregate
 
+import tamago.server.core.letter.domain.enum.LetterMood
 import tamago.server.core.letter.domain.vo.LetterContent
 import tamago.server.core.letter.domain.vo.LetterId
 import java.time.LocalDateTime
@@ -8,15 +9,17 @@ class Letter(
     val id: LetterId? = null,
     val title: String,
     val content: LetterContent,
+    val mood: LetterMood,
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null,
     val deletedAt: LocalDateTime? = null,
 ) {
     companion object {
-        fun create(title: String, content: String): Letter {
+        fun create(title: String, content: String, mood: LetterMood): Letter {
             return Letter(
                 title = title,
                 content = LetterContent(content),
+                mood = mood,
             )
         }
     }

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/aggregate/Letter.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/aggregate/Letter.kt
@@ -1,0 +1,23 @@
+package tamago.server.core.letter.domain.aggregate
+
+import tamago.server.core.letter.domain.vo.LetterContent
+import tamago.server.core.letter.domain.vo.LetterId
+import java.time.LocalDateTime
+
+class Letter(
+    val id: LetterId? = null,
+    val title: String,
+    val content: LetterContent,
+    val createdAt: LocalDateTime? = null,
+    val updatedAt: LocalDateTime? = null,
+    val deletedAt: LocalDateTime? = null,
+) {
+    companion object {
+        fun create(title: String, content: String): Letter {
+            return Letter(
+                title = title,
+                content = LetterContent(content),
+            )
+        }
+    }
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/aggregate/ReceivedLetter.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/aggregate/ReceivedLetter.kt
@@ -22,6 +22,8 @@ class ReceivedLetter(
         this.readStatus = ReadStatus.READ
     }
 
+    fun isOwnedBy(userId: UserId): Boolean = this.userId == userId
+
     companion object {
         fun create(userId: UserId, letterId: LetterId): ReceivedLetter {
             return ReceivedLetter(

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/aggregate/ReceivedLetter.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/aggregate/ReceivedLetter.kt
@@ -1,0 +1,34 @@
+package tamago.server.core.letter.domain.aggregate
+
+import tamago.server.core.letter.domain.enum.ReadStatus
+import tamago.server.core.letter.domain.vo.LetterId
+import tamago.server.core.letter.domain.vo.ReceivedLetterId
+import tamago.server.core.user.domain.vo.UserId
+import java.time.LocalDateTime
+
+class ReceivedLetter(
+    val id: ReceivedLetterId? = null,
+    val userId: UserId,
+    val letterId: LetterId,
+    readStatus: ReadStatus = ReadStatus.UNREAD,
+    val createdAt: LocalDateTime? = null,
+    val updatedAt: LocalDateTime? = null,
+    val deletedAt: LocalDateTime? = null,
+) {
+    var readStatus: ReadStatus = readStatus
+        private set
+
+    fun markAsRead() {
+        this.readStatus = ReadStatus.READ
+    }
+
+    companion object {
+        fun create(userId: UserId, letterId: LetterId): ReceivedLetter {
+            return ReceivedLetter(
+                userId = userId,
+                letterId = letterId,
+                readStatus = ReadStatus.UNREAD,
+            )
+        }
+    }
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/enum/LetterMood.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/enum/LetterMood.kt
@@ -1,0 +1,12 @@
+package tamago.server.core.letter.domain.enum
+
+enum class LetterMood(
+    val level: Int,
+) {
+    PROUD(5), // "연속 러닝, 목표 달성, 기록 갱신"
+    PRAISE(4),//  "오늘 달림"
+    ENCOURAGE(3), // "어제 달렸으니 오늘도 달리자"
+    WORRY(2), // "2~3일 안 달림"
+    SAD(1), // "일주일 이상 안 달림"
+    ;
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/enum/ReadStatus.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/enum/ReadStatus.kt
@@ -1,0 +1,6 @@
+package tamago.server.core.letter.domain.enum
+
+enum class ReadStatus {
+    UNREAD,
+    READ,
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/port/inbound/query/LetterInboxDto.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/port/inbound/query/LetterInboxDto.kt
@@ -1,0 +1,11 @@
+package tamago.server.core.letter.domain.port.inbound.query
+
+import tamago.server.core.letter.domain.enum.ReadStatus
+import tamago.server.core.letter.domain.vo.ReceivedLetterId
+
+data class LetterInboxDto(
+    val id: ReceivedLetterId,
+    val title: String,
+    val content: String,
+    val readStatus: ReadStatus,
+)

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/port/outbound/LetterPersistencePort.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/port/outbound/LetterPersistencePort.kt
@@ -1,10 +1,13 @@
 package tamago.server.core.letter.domain.port.outbound
 
 import tamago.server.core.letter.domain.aggregate.Letter
+import tamago.server.core.letter.domain.port.outbound.query.LetterInboxQueryModel
 import tamago.server.core.letter.domain.vo.LetterId
+import tamago.server.core.user.domain.vo.UserId
 
 interface LetterPersistencePort {
     fun save(letter: Letter): Letter
     fun findById(id: LetterId): Letter?
     fun findAll(): List<Letter>
+    fun findTopReceivedLetterByUserId(userId: UserId): LetterInboxQueryModel?
 }

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/port/outbound/LetterPersistencePort.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/port/outbound/LetterPersistencePort.kt
@@ -1,0 +1,10 @@
+package tamago.server.core.letter.domain.port.outbound
+
+import tamago.server.core.letter.domain.aggregate.Letter
+import tamago.server.core.letter.domain.vo.LetterId
+
+interface LetterPersistencePort {
+    fun save(letter: Letter): Letter
+    fun findById(id: LetterId): Letter?
+    fun findAll(): List<Letter>
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/port/outbound/ReceivedLetterPersistencePort.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/port/outbound/ReceivedLetterPersistencePort.kt
@@ -11,4 +11,5 @@ interface ReceivedLetterPersistencePort {
     fun findById(id: ReceivedLetterId): ReceivedLetter?
     fun findByUserId(userId: UserId): List<ReceivedLetter>
     fun findByUserIdAndLetterId(userId: UserId, letterId: LetterId): ReceivedLetter?
+    fun findLatestByUserId(userId: UserId): ReceivedLetter?
 }

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/port/outbound/ReceivedLetterPersistencePort.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/port/outbound/ReceivedLetterPersistencePort.kt
@@ -1,0 +1,14 @@
+package tamago.server.core.letter.domain.port.outbound
+
+import tamago.server.core.letter.domain.aggregate.ReceivedLetter
+import tamago.server.core.letter.domain.vo.LetterId
+import tamago.server.core.letter.domain.vo.ReceivedLetterId
+import tamago.server.core.user.domain.vo.UserId
+
+interface ReceivedLetterPersistencePort {
+    fun save(receivedLetter: ReceivedLetter): ReceivedLetter
+    fun saveAll(receivedLetters: List<ReceivedLetter>): List<ReceivedLetter>
+    fun findById(id: ReceivedLetterId): ReceivedLetter?
+    fun findByUserId(userId: UserId): List<ReceivedLetter>
+    fun findByUserIdAndLetterId(userId: UserId, letterId: LetterId): ReceivedLetter?
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/port/outbound/query/LetterInboxQueryModel.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/port/outbound/query/LetterInboxQueryModel.kt
@@ -1,0 +1,11 @@
+package tamago.server.core.letter.domain.port.outbound.query
+
+import tamago.server.core.letter.domain.enum.ReadStatus
+import tamago.server.core.letter.domain.vo.ReceivedLetterId
+
+data class LetterInboxQueryModel(
+    val id: ReceivedLetterId,
+    val title: String,
+    val content: String,
+    val readStatus: ReadStatus,
+)

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/vo/LetterContent.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/vo/LetterContent.kt
@@ -1,0 +1,12 @@
+package tamago.server.core.letter.domain.vo
+
+@JvmInline
+value class LetterContent(
+    val value: String,
+) {
+    init {
+        require(value.isNotBlank()) { "Letter content must not be blank" }
+    }
+
+    override fun toString(): String = value
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/vo/LetterId.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/vo/LetterId.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.letter.domain.vo
+
+@JvmInline
+value class LetterId(
+    val value: Long,
+) {
+    override fun toString(): String = value.toString()
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/domain/vo/ReceivedLetterId.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/domain/vo/ReceivedLetterId.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.letter.domain.vo
+
+@JvmInline
+value class ReceivedLetterId(
+    val value: Long,
+) {
+    override fun toString(): String = value.toString()
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/entity/LetterEntity.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/entity/LetterEntity.kt
@@ -2,12 +2,15 @@ package tamago.server.core.letter.infrastructure.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Lob
 import jakarta.persistence.Table
 import tamago.server.core.common.entity.BaseTimeEntity
+import tamago.server.core.letter.domain.enum.LetterMood
 
 @Entity
 @Table(name = "t_letters")
@@ -22,4 +25,8 @@ class LetterEntity(
     @Lob
     @Column(columnDefinition = "TEXT")
     val content: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mood")
+    val mood: LetterMood,
 ) : BaseTimeEntity()

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/entity/LetterEntity.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/entity/LetterEntity.kt
@@ -1,0 +1,25 @@
+package tamago.server.core.letter.infrastructure.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Lob
+import jakarta.persistence.Table
+import tamago.server.core.common.entity.BaseTimeEntity
+
+@Entity
+@Table(name = "t_letters")
+class LetterEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "letter_id")
+    val id: Long? = null,
+
+    val title: String,
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    val content: String,
+) : BaseTimeEntity()

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/entity/ReceivedLetterEntity.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/entity/ReceivedLetterEntity.kt
@@ -1,0 +1,42 @@
+package tamago.server.core.letter.infrastructure.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Table
+import tamago.server.core.common.entity.BaseTimeEntity
+import tamago.server.core.letter.domain.enum.ReadStatus
+
+@Entity
+@Table(name = "t_received_letters")
+class ReceivedLetterEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "received_letter_id")
+    val id: Long? = null,
+
+    @JoinColumn(
+        name = "user_id",
+        nullable = false,
+        foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
+    val userId: Long,
+
+    @JoinColumn(
+        name = "letter_id",
+        nullable = false,
+        foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
+    val letterId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "read_status")
+    var readStatus: ReadStatus = ReadStatus.UNREAD,
+) : BaseTimeEntity()

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/mapper/LetterMapper.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/mapper/LetterMapper.kt
@@ -1,0 +1,29 @@
+package tamago.server.core.letter.infrastructure.mapper
+
+import tamago.server.core.letter.domain.aggregate.Letter
+import tamago.server.core.letter.domain.vo.LetterContent
+import tamago.server.core.letter.domain.vo.LetterId
+import tamago.server.core.letter.infrastructure.entity.LetterEntity
+
+object LetterMapper {
+    fun toEntity(letter: Letter): LetterEntity {
+        return LetterEntity(
+            id = letter.id?.value,
+            title = letter.title,
+            content = letter.content.value,
+        )
+    }
+
+    fun toDomain(entity: LetterEntity?): Letter? {
+        if (entity == null) return null
+
+        return Letter(
+            id = entity.id?.let { LetterId(it) },
+            title = entity.title,
+            content = LetterContent(entity.content),
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt,
+            deletedAt = entity.deletedAt,
+        )
+    }
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/mapper/LetterMapper.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/mapper/LetterMapper.kt
@@ -11,6 +11,7 @@ object LetterMapper {
             id = letter.id?.value,
             title = letter.title,
             content = letter.content.value,
+            mood = letter.mood,
         )
     }
 
@@ -21,6 +22,7 @@ object LetterMapper {
             id = entity.id?.let { LetterId(it) },
             title = entity.title,
             content = LetterContent(entity.content),
+            mood = entity.mood,
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt,
             deletedAt = entity.deletedAt,

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/mapper/ReceivedLetterMapper.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/mapper/ReceivedLetterMapper.kt
@@ -1,0 +1,32 @@
+package tamago.server.core.letter.infrastructure.mapper
+
+import tamago.server.core.letter.domain.aggregate.ReceivedLetter
+import tamago.server.core.letter.domain.vo.LetterId
+import tamago.server.core.letter.domain.vo.ReceivedLetterId
+import tamago.server.core.letter.infrastructure.entity.ReceivedLetterEntity
+import tamago.server.core.user.domain.vo.UserId
+
+object ReceivedLetterMapper {
+    fun toEntity(receivedLetter: ReceivedLetter): ReceivedLetterEntity {
+        return ReceivedLetterEntity(
+            id = receivedLetter.id?.value,
+            userId = receivedLetter.userId.value,
+            letterId = receivedLetter.letterId.value,
+            readStatus = receivedLetter.readStatus,
+        )
+    }
+
+    fun toDomain(entity: ReceivedLetterEntity?): ReceivedLetter? {
+        if (entity == null) return null
+
+        return ReceivedLetter(
+            id = entity.id?.let { ReceivedLetterId(it) },
+            userId = UserId(entity.userId),
+            letterId = LetterId(entity.letterId),
+            readStatus = entity.readStatus,
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt,
+            deletedAt = entity.deletedAt,
+        )
+    }
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/LetterJpaRepository.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/LetterJpaRepository.kt
@@ -1,6 +1,7 @@
 package tamago.server.core.letter.infrastructure.repository
 
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import org.springframework.data.jpa.repository.JpaRepository
 import tamago.server.core.letter.infrastructure.entity.LetterEntity
 
-interface LetterJpaRepository : JpaRepository<LetterEntity, Long>
+interface LetterJpaRepository : JpaRepository<LetterEntity, Long>, KotlinJdslJpqlExecutor

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/LetterJpaRepository.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/LetterJpaRepository.kt
@@ -1,0 +1,6 @@
+package tamago.server.core.letter.infrastructure.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import tamago.server.core.letter.infrastructure.entity.LetterEntity
+
+interface LetterJpaRepository : JpaRepository<LetterEntity, Long>

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/LetterPersistenceAdapter.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/LetterPersistenceAdapter.kt
@@ -1,14 +1,19 @@
 package tamago.server.core.letter.infrastructure.repository
 
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Repository
 import tamago.server.core.letter.domain.aggregate.Letter
 import tamago.server.core.letter.domain.port.outbound.LetterPersistencePort
+import tamago.server.core.letter.domain.port.outbound.query.LetterInboxQueryModel
 import tamago.server.core.letter.domain.vo.LetterId
+import tamago.server.core.letter.infrastructure.entity.LetterEntity
+import tamago.server.core.letter.infrastructure.entity.ReceivedLetterEntity
 import tamago.server.core.letter.infrastructure.mapper.LetterMapper
+import tamago.server.core.user.domain.vo.UserId
 
 @Repository
 class LetterPersistenceAdapter(
-    private val letterJpaRepository: LetterJpaRepository
+    private val letterJpaRepository: LetterJpaRepository,
 ) : LetterPersistencePort {
     override fun save(letter: Letter): Letter =
         LetterMapper.toDomain(letterJpaRepository.save(LetterMapper.toEntity(letter)))!!
@@ -18,4 +23,24 @@ class LetterPersistenceAdapter(
 
     override fun findAll(): List<Letter> =
         letterJpaRepository.findAll().mapNotNull { LetterMapper.toDomain(it) }
+
+    override fun findTopReceivedLetterByUserId(userId: UserId): LetterInboxQueryModel? {
+        return letterJpaRepository.findPage(PageRequest.of(0, 1)) {
+            selectNew<LetterInboxQueryModel>(
+                path(ReceivedLetterEntity::id),
+                path(LetterEntity::title),
+                path(LetterEntity::content),
+                path(ReceivedLetterEntity::readStatus),
+            ).from(
+                entity(ReceivedLetterEntity::class),
+                join(LetterEntity::class).on(
+                    path(ReceivedLetterEntity::letterId).eq(path(LetterEntity::id))
+                ),
+            ).where(
+                path(ReceivedLetterEntity::userId).eq(userId.value)
+            ).orderBy(
+                path(ReceivedLetterEntity::createdAt).desc()
+            )
+        }.content.firstOrNull()
+    }
 }

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/LetterPersistenceAdapter.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/LetterPersistenceAdapter.kt
@@ -1,0 +1,21 @@
+package tamago.server.core.letter.infrastructure.repository
+
+import org.springframework.stereotype.Repository
+import tamago.server.core.letter.domain.aggregate.Letter
+import tamago.server.core.letter.domain.port.outbound.LetterPersistencePort
+import tamago.server.core.letter.domain.vo.LetterId
+import tamago.server.core.letter.infrastructure.mapper.LetterMapper
+
+@Repository
+class LetterPersistenceAdapter(
+    private val letterJpaRepository: LetterJpaRepository
+) : LetterPersistencePort {
+    override fun save(letter: Letter): Letter =
+        LetterMapper.toDomain(letterJpaRepository.save(LetterMapper.toEntity(letter)))!!
+
+    override fun findById(id: LetterId): Letter? =
+        LetterMapper.toDomain(letterJpaRepository.findById(id.value).orElse(null))
+
+    override fun findAll(): List<Letter> =
+        letterJpaRepository.findAll().mapNotNull { LetterMapper.toDomain(it) }
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/ReceivedLetterJpaRepository.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/ReceivedLetterJpaRepository.kt
@@ -6,4 +6,5 @@ import tamago.server.core.letter.infrastructure.entity.ReceivedLetterEntity
 interface ReceivedLetterJpaRepository : JpaRepository<ReceivedLetterEntity, Long> {
     fun findByUserId(userId: Long): List<ReceivedLetterEntity>
     fun findByUserIdAndLetterId(userId: Long, letterId: Long): ReceivedLetterEntity?
+    fun findTopByUserIdOrderByCreatedAtDesc(userId: Long): ReceivedLetterEntity?
 }

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/ReceivedLetterJpaRepository.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/ReceivedLetterJpaRepository.kt
@@ -1,0 +1,9 @@
+package tamago.server.core.letter.infrastructure.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import tamago.server.core.letter.infrastructure.entity.ReceivedLetterEntity
+
+interface ReceivedLetterJpaRepository : JpaRepository<ReceivedLetterEntity, Long> {
+    fun findByUserId(userId: Long): List<ReceivedLetterEntity>
+    fun findByUserIdAndLetterId(userId: Long, letterId: Long): ReceivedLetterEntity?
+}

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/ReceivedLetterPersistenceAdapter.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/ReceivedLetterPersistenceAdapter.kt
@@ -27,4 +27,7 @@ class ReceivedLetterPersistenceAdapter(
 
     override fun findByUserIdAndLetterId(userId: UserId, letterId: LetterId): ReceivedLetter? =
         ReceivedLetterMapper.toDomain(receivedLetterJpaRepository.findByUserIdAndLetterId(userId.value, letterId.value))
+
+    override fun findLatestByUserId(userId: UserId): ReceivedLetter? =
+        ReceivedLetterMapper.toDomain(receivedLetterJpaRepository.findTopByUserIdOrderByCreatedAtDesc(userId.value))
 }

--- a/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/ReceivedLetterPersistenceAdapter.kt
+++ b/core/src/main/kotlin/tamago/server/core/letter/infrastructure/repository/ReceivedLetterPersistenceAdapter.kt
@@ -1,0 +1,30 @@
+package tamago.server.core.letter.infrastructure.repository
+
+import org.springframework.stereotype.Repository
+import tamago.server.core.letter.domain.aggregate.ReceivedLetter
+import tamago.server.core.letter.domain.port.outbound.ReceivedLetterPersistencePort
+import tamago.server.core.letter.domain.vo.LetterId
+import tamago.server.core.letter.domain.vo.ReceivedLetterId
+import tamago.server.core.letter.infrastructure.mapper.ReceivedLetterMapper
+import tamago.server.core.user.domain.vo.UserId
+
+@Repository
+class ReceivedLetterPersistenceAdapter(
+    private val receivedLetterJpaRepository: ReceivedLetterJpaRepository
+) : ReceivedLetterPersistencePort {
+    override fun save(receivedLetter: ReceivedLetter): ReceivedLetter =
+        ReceivedLetterMapper.toDomain(receivedLetterJpaRepository.save(ReceivedLetterMapper.toEntity(receivedLetter)))!!
+
+    override fun saveAll(receivedLetters: List<ReceivedLetter>): List<ReceivedLetter> =
+        receivedLetterJpaRepository.saveAll(receivedLetters.map { ReceivedLetterMapper.toEntity(it) })
+            .mapNotNull { ReceivedLetterMapper.toDomain(it) }
+
+    override fun findById(id: ReceivedLetterId): ReceivedLetter? =
+        ReceivedLetterMapper.toDomain(receivedLetterJpaRepository.findById(id.value).orElse(null))
+
+    override fun findByUserId(userId: UserId): List<ReceivedLetter> =
+        receivedLetterJpaRepository.findByUserId(userId.value).mapNotNull { ReceivedLetterMapper.toDomain(it) }
+
+    override fun findByUserIdAndLetterId(userId: UserId, letterId: LetterId): ReceivedLetter? =
+        ReceivedLetterMapper.toDomain(receivedLetterJpaRepository.findByUserIdAndLetterId(userId.value, letterId.value))
+}

--- a/core/src/main/kotlin/tamago/server/core/notification/domain/aggregate/Notification.kt
+++ b/core/src/main/kotlin/tamago/server/core/notification/domain/aggregate/Notification.kt
@@ -10,6 +10,7 @@ class Notification(
     val content: String? = null,
     isRead: Boolean = false,
     val userId: UserId,
+    val scheduledAt: LocalDateTime? = null,
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null,
     val deletedAt: LocalDateTime? = null,
@@ -21,13 +22,21 @@ class Notification(
         this.isRead = true
     }
 
+    fun isScheduled(): Boolean = scheduledAt != null
+
     companion object {
-        fun create(userId: UserId, title: String, content: String): Notification {
+        fun create(
+            userId: UserId,
+            title: String,
+            content: String,
+            scheduledAt: LocalDateTime? = null,
+        ): Notification {
             return Notification(
                 userId = userId,
                 title = title,
                 content = content,
                 isRead = false,
+                scheduledAt = scheduledAt,
             )
         }
     }

--- a/core/src/main/kotlin/tamago/server/core/notification/infrastructure/entity/NotificationEntity.kt
+++ b/core/src/main/kotlin/tamago/server/core/notification/infrastructure/entity/NotificationEntity.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.Table
 import tamago.server.core.common.entity.BaseTimeEntity
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "t_notifications")
@@ -32,4 +33,7 @@ class NotificationEntity(
         foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
     )
     val userId: Long,
+
+    @Column(name = "scheduled_at")
+    val scheduledAt: LocalDateTime? = null,
 ) : BaseTimeEntity()

--- a/core/src/main/kotlin/tamago/server/core/notification/infrastructure/mapper/NotificationMapper.kt
+++ b/core/src/main/kotlin/tamago/server/core/notification/infrastructure/mapper/NotificationMapper.kt
@@ -13,6 +13,7 @@ object NotificationMapper {
             content = notification.content,
             isRead = notification.isRead,
             userId = notification.userId.value,
+            scheduledAt = notification.scheduledAt,
         )
     }
 
@@ -25,6 +26,7 @@ object NotificationMapper {
             content = entity.content,
             isRead = entity.isRead,
             userId = UserId(entity.userId),
+            scheduledAt = entity.scheduledAt,
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt,
             deletedAt = entity.deletedAt,

--- a/core/src/main/kotlin/tamago/server/core/user/UserFacade.kt
+++ b/core/src/main/kotlin/tamago/server/core/user/UserFacade.kt
@@ -49,18 +49,18 @@ class UserFacade(
             userId = userId.value,
             accessToken = accessToken,
             refreshToken = refreshToken,
-            isNewUser = false,
+            isNewUser = !user.isOnboarded(),
         )
     }
 
     fun reissueToken(refreshToken: String): TokenQueryDto {
         val userId = jwtTokenProvider.getUserId(refreshToken)
-        val role = jwtTokenProvider.getUserRole(refreshToken)
+        val user = userQueryUseCase.get(userId)
 
         refreshTokenQueryUseCase.validation(userId, refreshToken)
 
-        val newAccessToken = jwtTokenProvider.generateAccessToken(userId, role)
-        val newRefreshToken = jwtTokenProvider.generateRefreshToken(userId, role)
+        val newAccessToken = jwtTokenProvider.generateAccessToken(userId, user.role)
+        val newRefreshToken = jwtTokenProvider.generateRefreshToken(userId, user.role)
 
         refreshTokenCommandUseCase.rotate(userId, newRefreshToken)
 
@@ -68,7 +68,7 @@ class UserFacade(
             userId = userId.value,
             accessToken = newAccessToken,
             refreshToken = newRefreshToken,
-            isNewUser = false,
+            isNewUser = !user.isOnboarded(),
         )
     }
 }

--- a/core/src/main/kotlin/tamago/server/core/user/application/service/UserCommandService.kt
+++ b/core/src/main/kotlin/tamago/server/core/user/application/service/UserCommandService.kt
@@ -48,7 +48,7 @@ class UserCommandService(
             userId = userId.value,
             accessToken = accessToken,
             refreshToken = refreshToken,
-            isNewUser = isNewUser,
+            isNewUser = !user.isOnboarded(),
         )
     }
 

--- a/core/src/main/kotlin/tamago/server/core/user/domain/aggregate/User.kt
+++ b/core/src/main/kotlin/tamago/server/core/user/domain/aggregate/User.kt
@@ -41,6 +41,10 @@ class User(
         this.runningData = runningData.updateGoalKilo(goalKilo)
     }
 
+    fun isOnboarded(): Boolean {
+        return !nickname.isNullOrBlank() && runningData.goalKilo != null
+    }
+
     companion object {
         fun create(
             email: String,

--- a/core/src/main/kotlin/tamago/server/core/user/domain/aggregate/User.kt
+++ b/core/src/main/kotlin/tamago/server/core/user/domain/aggregate/User.kt
@@ -10,7 +10,7 @@ class User(
     nickname: String? = null,
     val role: UserRole = UserRole.USER,
     auths: List<UserAuth> = emptyList(),
-    goalKilo: Int? = null,
+    runningData: UserRunningData = UserRunningData(),
     lastLoginAt: LocalDateTime? = null,
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null,
@@ -23,7 +23,7 @@ class User(
         .sortedBy { it.provider }
         .toList()
 
-    var goalKilo: Int? = goalKilo
+    var runningData: UserRunningData = runningData
         private set
 
     var lastLoginAt: LocalDateTime? = lastLoginAt
@@ -38,7 +38,7 @@ class User(
     }
 
     fun updateGoalKilo(goalKilo: Int) {
-        this.goalKilo = goalKilo
+        this.runningData = runningData.updateGoalKilo(goalKilo)
     }
 
     companion object {

--- a/core/src/main/kotlin/tamago/server/core/user/domain/aggregate/UserRunningData.kt
+++ b/core/src/main/kotlin/tamago/server/core/user/domain/aggregate/UserRunningData.kt
@@ -2,13 +2,13 @@ package tamago.server.core.user.domain.aggregate
 
 data class UserRunningData(
     val goalKilo: Int? = null,
-    val totalKilo: Int? = null,
+    val totalKilo: Double? = null,
 ) {
     fun updateGoalKilo(goalKilo: Int): UserRunningData {
         return copy(goalKilo = goalKilo)
     }
 
-    fun addKilo(kilo: Int): UserRunningData {
-        return copy(totalKilo = (totalKilo ?: 0) + kilo)
+    fun addKilo(kilo: Double): UserRunningData {
+        return copy(totalKilo = (totalKilo ?: 0.0) + kilo)
     }
 }

--- a/core/src/main/kotlin/tamago/server/core/user/domain/aggregate/UserRunningData.kt
+++ b/core/src/main/kotlin/tamago/server/core/user/domain/aggregate/UserRunningData.kt
@@ -1,0 +1,14 @@
+package tamago.server.core.user.domain.aggregate
+
+data class UserRunningData(
+    val goalKilo: Int? = null,
+    val totalKilo: Int? = null,
+) {
+    fun updateGoalKilo(goalKilo: Int): UserRunningData {
+        return copy(goalKilo = goalKilo)
+    }
+
+    fun addKilo(kilo: Int): UserRunningData {
+        return copy(totalKilo = (totalKilo ?: 0) + kilo)
+    }
+}

--- a/core/src/main/kotlin/tamago/server/core/user/domain/enum/UserRole.kt
+++ b/core/src/main/kotlin/tamago/server/core/user/domain/enum/UserRole.kt
@@ -2,5 +2,6 @@ package tamago.server.core.user.domain.enum
 
 enum class UserRole {
     USER,
+    ADMIN
     ;
 }

--- a/core/src/main/kotlin/tamago/server/core/user/infrastructure/entity/UserEntity.kt
+++ b/core/src/main/kotlin/tamago/server/core/user/infrastructure/entity/UserEntity.kt
@@ -33,5 +33,6 @@ class UserEntity(
     )
     val auths: MutableList<UserAuthEntity> = mutableListOf(),
     var goalKilo: Int? = null,
+    var totalKilo: Int? = null,
     var lastLoginAt: LocalDateTime? = null,
 ) : BaseTimeEntity()

--- a/core/src/main/kotlin/tamago/server/core/user/infrastructure/entity/UserEntity.kt
+++ b/core/src/main/kotlin/tamago/server/core/user/infrastructure/entity/UserEntity.kt
@@ -33,6 +33,6 @@ class UserEntity(
     )
     val auths: MutableList<UserAuthEntity> = mutableListOf(),
     var goalKilo: Int? = null,
-    var totalKilo: Int? = null,
+    var totalKilo: Double? = null,
     var lastLoginAt: LocalDateTime? = null,
 ) : BaseTimeEntity()

--- a/core/src/main/kotlin/tamago/server/core/user/infrastructure/mapper/UserMapper.kt
+++ b/core/src/main/kotlin/tamago/server/core/user/infrastructure/mapper/UserMapper.kt
@@ -2,6 +2,7 @@ package tamago.server.core.user.infrastructure.mapper
 
 import tamago.server.core.user.domain.aggregate.User
 import tamago.server.core.user.domain.vo.UserId
+import tamago.server.core.user.domain.aggregate.UserRunningData
 import tamago.server.core.user.infrastructure.entity.UserEntity
 
 object UserMapper {
@@ -10,7 +11,8 @@ object UserMapper {
             id = user.id?.value,
             nickname = user.nickname,
             role = user.role,
-            goalKilo = user.goalKilo,
+            goalKilo = user.runningData.goalKilo,
+            totalKilo = user.runningData.totalKilo,
             lastLoginAt = user.lastLoginAt,
         )
 
@@ -31,7 +33,10 @@ object UserMapper {
             nickname = entity.nickname,
             role = entity.role,
             auths = UserAuthMapper.toDomain(entity.auths),
-            goalKilo = entity.goalKilo,
+            runningData = UserRunningData(
+                goalKilo = entity.goalKilo,
+                totalKilo = entity.totalKilo,
+            ),
             lastLoginAt = entity.lastLoginAt,
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt,

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/auth/v1/controller/AuthController.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/auth/v1/controller/AuthController.kt
@@ -58,6 +58,7 @@ class AuthController(
                 userId = token.userId,
                 accessToken = token.accessToken,
                 refreshToken = token.refreshToken,
+                newUser = token.isNewUser
             )
         )
     }

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/auth/v1/controller/TestAuthController.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/auth/v1/controller/TestAuthController.kt
@@ -48,6 +48,7 @@ class TestAuthController(
                 userId = token.userId,
                 accessToken = token.accessToken,
                 refreshToken = token.refreshToken,
+                newUser = token.isNewUser,
             )
         )
     }

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/auth/v1/response/LoginResponse.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/auth/v1/response/LoginResponse.kt
@@ -11,4 +11,7 @@ data class LoginResponse(
 
     @field:Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", requiredMode = Schema.RequiredMode.REQUIRED)
     val refreshToken: String,
+
+    @field:Schema(description = "신규 유저 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+    val newUser: Boolean,
 )

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/api/LetterApi.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/api/LetterApi.kt
@@ -1,5 +1,6 @@
 package tamago.server.gateway.presentation.letter.v1.api
 
+import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import tamago.server.core.letter.domain.vo.ReceivedLetterId
@@ -16,6 +17,7 @@ interface LetterApi {
     @Operation(summary = "편지 수신 확인", description = "가장 최근 받은 편지를 읽음 처리합니다.")
     fun markAsReadLetter(user: User, letterId: ReceivedLetterId): CustomResponse<Void>
 
+    @Hidden
     @Operation(summary = "편지 템플릿 데이터 삽입", description = "편지 템플릿에 데이터를 삽입하여 편지 내용을 생성합니다.")
     fun createTemplate(request: LetterCreate): CustomResponse<Void>
 }

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/api/LetterApi.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/api/LetterApi.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import tamago.server.core.letter.domain.vo.ReceivedLetterId
 import tamago.server.core.user.domain.aggregate.User
+import tamago.server.gateway.presentation.letter.v1.request.LetterCreate
 import tamago.server.gateway.presentation.letter.v1.response.LetterResponse
 import tamago.server.gateway.response.CustomResponse
 
@@ -14,4 +15,7 @@ interface LetterApi {
 
     @Operation(summary = "편지 수신 확인", description = "가장 최근 받은 편지를 읽음 처리합니다.")
     fun markAsReadLetter(user: User, letterId: ReceivedLetterId): CustomResponse<Void>
+
+    @Operation(summary = "편지 템플릿 데이터 삽입", description = "편지 템플릿에 데이터를 삽입하여 편지 내용을 생성합니다.")
+    fun createTemplate(request: LetterCreate): CustomResponse<Void>
 }

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/api/LetterApi.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/api/LetterApi.kt
@@ -1,0 +1,17 @@
+package tamago.server.gateway.presentation.letter.v1.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import tamago.server.core.letter.domain.vo.ReceivedLetterId
+import tamago.server.core.user.domain.aggregate.User
+import tamago.server.gateway.presentation.letter.v1.response.LetterResponse
+import tamago.server.gateway.response.CustomResponse
+
+@Tag(name = "Letter API", description = "타마고의 편지 API")
+interface LetterApi {
+    @Operation(summary = "편지 수신함 조회", description = "가장 최근 받은 편지 한 개를 조회합니다.")
+    fun readLetterInbox(user: User): CustomResponse<LetterResponse>
+
+    @Operation(summary = "편지 수신 확인", description = "가장 최근 받은 편지를 읽음 처리합니다.")
+    fun markAsReadLetter(user: User, letterId: ReceivedLetterId): CustomResponse<Void>
+}

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
@@ -23,7 +23,7 @@ class LetterController(
     private val letterFacade: LetterFacade,
 ) : LetterApi {
 
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/api/v1/letters")
     override fun readLetterInbox(@CurrentUser user: User): CustomResponse<LetterResponse> {
         val result = letterQueryUseCase.getLatestReceivedLetter(user.id!!)
@@ -39,7 +39,7 @@ class LetterController(
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @PatchMapping("/api/v1/letters/read")
     override fun markAsReadLetter(
         @CurrentUser user: User,
@@ -50,7 +50,7 @@ class LetterController(
     }
 
     @ResponseStatus(HttpStatus.CREATED)
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/api/v1/letters")
     override fun createTemplate(@RequestBody @Valid request: LetterCreate): CustomResponse<Void> {
         letterCommandUseCase.createTemplate(

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
@@ -1,0 +1,51 @@
+package tamago.server.gateway.presentation.letter.v1.controller
+
+import io.swagger.v3.oas.annotations.Parameter
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import tamago.server.core.letter.LetterFacade
+import tamago.server.core.letter.LetterQueryUseCase
+import tamago.server.core.letter.domain.vo.ReceivedLetterId
+import tamago.server.core.user.domain.aggregate.User
+import tamago.server.gateway.presentation.letter.v1.api.LetterApi
+import tamago.server.gateway.presentation.letter.v1.response.LetterResponse
+import tamago.server.gateway.response.CustomResponse
+import tamago.server.gateway.security.annotation.CurrentUser
+
+@RestController
+class LetterController(
+    private val letterQueryUseCase: LetterQueryUseCase,
+    private val letterFacade: LetterFacade,
+) : LetterApi {
+
+    @PreAuthorize("hasRole('USER')")
+    @GetMapping("/api/v1/letters")
+    override fun readLetterInbox(@CurrentUser user: User): CustomResponse<LetterResponse> {
+        val result = letterQueryUseCase.getLatestReceivedLetter(user.id!!)
+            ?: return CustomResponse.ok(null)
+
+        return CustomResponse.ok(
+            LetterResponse(
+                letterId = result.id.value,
+                content = result.content,
+                readStatus = result.readStatus,
+            ),
+        )
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasRole('USER')")
+    @PostMapping("/api/v1/letters/read")
+    override fun markAsReadLetter(
+        @CurrentUser user: User,
+        @RequestParam @Parameter(required = true) letterId: ReceivedLetterId,
+    ): CustomResponse<Void> {
+        letterFacade.markAsRead(letterId)
+        return CustomResponse.noContent()
+    }
+}

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
@@ -1,18 +1,17 @@
 package tamago.server.gateway.presentation.letter.v1.controller
 
 import io.swagger.v3.oas.annotations.Parameter
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import tamago.server.core.letter.LetterCommandUseCase
 import tamago.server.core.letter.LetterFacade
 import tamago.server.core.letter.LetterQueryUseCase
 import tamago.server.core.letter.domain.vo.ReceivedLetterId
 import tamago.server.core.user.domain.aggregate.User
 import tamago.server.gateway.presentation.letter.v1.api.LetterApi
+import tamago.server.gateway.presentation.letter.v1.request.LetterCreate
 import tamago.server.gateway.presentation.letter.v1.response.LetterResponse
 import tamago.server.gateway.response.CustomResponse
 import tamago.server.gateway.security.annotation.CurrentUser
@@ -20,10 +19,11 @@ import tamago.server.gateway.security.annotation.CurrentUser
 @RestController
 class LetterController(
     private val letterQueryUseCase: LetterQueryUseCase,
+    private val letterCommandUseCase: LetterCommandUseCase,
     private val letterFacade: LetterFacade,
 ) : LetterApi {
 
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/api/v1/letters")
     override fun readLetterInbox(@CurrentUser user: User): CustomResponse<LetterResponse> {
         val result = letterQueryUseCase.getLatestReceivedLetter(user.id!!)
@@ -39,13 +39,26 @@ class LetterController(
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PreAuthorize("hasRole('USER')")
-    @PostMapping("/api/v1/letters/read")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PatchMapping("/api/v1/letters/read")
     override fun markAsReadLetter(
         @CurrentUser user: User,
         @RequestParam @Parameter(required = true) letterId: ReceivedLetterId,
     ): CustomResponse<Void> {
         letterFacade.markAsRead(letterId)
         return CustomResponse.noContent()
+    }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/api/v1/letters")
+    override fun createTemplate(@RequestBody @Valid request: LetterCreate): CustomResponse<Void> {
+        letterCommandUseCase.createTemplate(
+            title = request.title,
+            content = request.content,
+            mood = request.mood
+        )
+
+        return CustomResponse.created()
     }
 }

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
@@ -45,7 +45,7 @@ class LetterController(
         @CurrentUser user: User,
         @RequestParam @Parameter(required = true) letterId: ReceivedLetterId,
     ): CustomResponse<Void> {
-        letterFacade.markAsRead(letterId)
+        letterFacade.markAsRead(user, letterId)
         return CustomResponse.noContent()
     }
 

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
@@ -23,7 +23,7 @@ class LetterController(
     private val letterFacade: LetterFacade,
 ) : LetterApi {
 
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/api/v1/letters")
     override fun readLetterInbox(@CurrentUser user: User): CustomResponse<LetterResponse> {
         val result = letterQueryUseCase.getLatestReceivedLetter(user.id!!)
@@ -39,7 +39,7 @@ class LetterController(
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/api/v1/letters/read")
     override fun markAsReadLetter(
         @CurrentUser user: User,
@@ -50,7 +50,7 @@ class LetterController(
     }
 
     @ResponseStatus(HttpStatus.CREATED)
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/api/v1/letters")
     override fun createTemplate(@RequestBody @Valid request: LetterCreate): CustomResponse<Void> {
         letterCommandUseCase.createTemplate(

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/request/LetterCreate.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/request/LetterCreate.kt
@@ -1,0 +1,20 @@
+package tamago.server.gateway.presentation.letter.v1.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import tamago.server.core.letter.domain.enum.LetterMood
+
+data class LetterCreate(
+    @field:Schema(description = "편지 제목", example = "템플릿 제목", requiredMode = Schema.RequiredMode.REQUIRED)
+    @field:NotBlank(message = "제목은 필수입니다.")
+    val title: String,
+
+    @field:Schema(description = "편지 내용", example = "오늘도 열심히 달린 당신, 정말 대단해요!", requiredMode = Schema.RequiredMode.REQUIRED)
+    @field:NotBlank(message = "내용은 필수입니다.")
+    val content: String,
+
+    @field:Schema(description = "편지 분위기", example = "PRAISE", requiredMode = Schema.RequiredMode.REQUIRED)
+    @field:NotNull(message = "무드 지정은 필수입니다.")
+    val mood: LetterMood,
+)

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/response/LetterResponse.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/response/LetterResponse.kt
@@ -1,0 +1,15 @@
+package tamago.server.gateway.presentation.letter.v1.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import tamago.server.core.letter.domain.enum.ReadStatus
+
+data class LetterResponse(
+    @field:Schema(description = "편지 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    val letterId: Long,
+
+    @field:Schema(description = "편지 내용", example = "안녕하세요, 타마고입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
+    val content: String,
+
+    @field:Schema(description = "읽음 상태", example = "UNREAD", requiredMode = Schema.RequiredMode.REQUIRED)
+    val readStatus: ReadStatus,
+)

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/notification/v1/api/NotificationApi.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/notification/v1/api/NotificationApi.kt
@@ -1,0 +1,7 @@
+package tamago.server.gateway.presentation.notification.v1.api
+
+import io.swagger.v3.oas.annotations.tags.Tag
+
+@Tag(name = "Notification API", description = "푸시 알림 관련 API")
+interface NotificationApi {
+}

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/api/UserApi.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/api/UserApi.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import tamago.server.core.user.domain.aggregate.User
 import tamago.server.gateway.presentation.user.v1.request.GoalKiloRequest
 import tamago.server.gateway.presentation.user.v1.request.NicknameRequest
+import tamago.server.gateway.presentation.user.v1.response.RunningDataResponse
 import tamago.server.gateway.response.CustomResponse
 
 @Tag(name = "User API", description = "유저 관련 API")
@@ -14,4 +15,7 @@ interface UserApi {
 
     @Operation(summary = "하루 러닝 목표 설정", description = "하루 러닝 목표를 정합니다.")
     fun setRunningGoal(user: User, request: GoalKiloRequest): CustomResponse<Void>
+
+    @Operation(summary = "누적 러닝 거리와 러닝 일수를 반환", description = "누적 러닝 거리와 러닝 일수를 반환합니다.")
+    fun getRunningData(user: User): CustomResponse<RunningDataResponse>
 }

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/controller/UserController.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/controller/UserController.kt
@@ -22,7 +22,7 @@ class UserController(
     private val userCommandUseCase: UserCommandUseCase,
 ) : UserApi {
 
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @PatchMapping("/api/v1/users/nickname")
     override fun giveNickname(
         @CurrentUser user: User,
@@ -32,7 +32,7 @@ class UserController(
         return CustomResponse.ok()
     }
 
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @PatchMapping("/api/v1/users/running-goal")
     override fun setRunningGoal(
         @CurrentUser user: User,
@@ -42,7 +42,7 @@ class UserController(
         return CustomResponse.ok()
     }
 
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/api/v1/users/running-data")
     override fun getRunningData(
         @CurrentUser user: User

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/controller/UserController.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/controller/UserController.kt
@@ -2,6 +2,7 @@ package tamago.server.gateway.presentation.user.v1.controller
 
 import jakarta.validation.Valid
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -10,8 +11,11 @@ import tamago.server.core.user.domain.aggregate.User
 import tamago.server.gateway.presentation.user.v1.api.UserApi
 import tamago.server.gateway.presentation.user.v1.request.GoalKiloRequest
 import tamago.server.gateway.presentation.user.v1.request.NicknameRequest
+import tamago.server.gateway.presentation.user.v1.response.RunningDataResponse
 import tamago.server.gateway.response.CustomResponse
 import tamago.server.gateway.security.annotation.CurrentUser
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 
 @RestController
 class UserController(
@@ -36,5 +40,20 @@ class UserController(
     ): CustomResponse<Void> {
         userCommandUseCase.updateGoalKilo(user, request.goalKilo)
         return CustomResponse.ok()
+    }
+
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/api/v1/users/running-data")
+    override fun getRunningData(
+        @CurrentUser user: User
+    ): CustomResponse<RunningDataResponse> {
+        val runningDays = user.createdAt?.let {
+            ChronoUnit.DAYS.between(it.toLocalDate(), LocalDate.now()) + 1
+        } ?: 1
+        val response = RunningDataResponse(
+            totalKilo = user.runningData.totalKilo ?: 0,
+            runningDays = runningDays,
+        )
+        return CustomResponse.ok(response)
     }
 }

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/controller/UserController.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/controller/UserController.kt
@@ -22,7 +22,7 @@ class UserController(
     private val userCommandUseCase: UserCommandUseCase,
 ) : UserApi {
 
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/api/v1/users/nickname")
     override fun giveNickname(
         @CurrentUser user: User,
@@ -32,7 +32,7 @@ class UserController(
         return CustomResponse.ok()
     }
 
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/api/v1/users/running-goal")
     override fun setRunningGoal(
         @CurrentUser user: User,
@@ -42,7 +42,7 @@ class UserController(
         return CustomResponse.ok()
     }
 
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/api/v1/users/running-data")
     override fun getRunningData(
         @CurrentUser user: User

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/controller/UserController.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/controller/UserController.kt
@@ -51,7 +51,7 @@ class UserController(
             ChronoUnit.DAYS.between(it.toLocalDate(), LocalDate.now()) + 1
         } ?: 1
         val response = RunningDataResponse(
-            totalKilo = user.runningData.totalKilo ?: 0,
+            totalKilo = user.runningData.totalKilo ?: 0.0,
             runningDays = runningDays,
         )
         return CustomResponse.ok(response)

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/response/RunningDataResponse.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/response/RunningDataResponse.kt
@@ -1,0 +1,11 @@
+package tamago.server.gateway.presentation.user.v1.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class RunningDataResponse(
+    @field:Schema(description = "누적 러닝 거리 (km)", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
+    val totalKilo: Int,
+
+    @field:Schema(description = "러닝 시작 후 경과 일수", example = "7", requiredMode = Schema.RequiredMode.REQUIRED)
+    val runningDays: Long,
+)

--- a/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/response/RunningDataResponse.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/response/RunningDataResponse.kt
@@ -3,8 +3,8 @@ package tamago.server.gateway.presentation.user.v1.response
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class RunningDataResponse(
-    @field:Schema(description = "누적 러닝 거리 (km)", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
-    val totalKilo: Int,
+    @field:Schema(description = "누적 러닝 거리 (km)", example = "42.5", requiredMode = Schema.RequiredMode.REQUIRED)
+    val totalKilo: Double,
 
     @field:Schema(description = "러닝 시작 후 경과 일수", example = "7", requiredMode = Schema.RequiredMode.REQUIRED)
     val runningDays: Long,

--- a/gateway/src/main/kotlin/tamago/server/gateway/response/CustomResponse.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/response/CustomResponse.kt
@@ -48,11 +48,10 @@ data class CustomResponse<T>(
             data = data
         )
 
-        fun <T> created(data: T): CustomResponse<T> = CustomResponse(
+        fun <T> created(): CustomResponse<T> = CustomResponse(
             status = GlobalExceptionCode.CREATED.status,
             message = GlobalExceptionCode.CREATED.message,
             code = GlobalExceptionCode.CREATED.code,
-            data = data
         )
 
         fun noContent(): CustomResponse<Void> = CustomResponse(

--- a/gateway/src/main/kotlin/tamago/server/gateway/response/CustomResponse.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/response/CustomResponse.kt
@@ -55,7 +55,7 @@ data class CustomResponse<T>(
             data = data
         )
 
-        fun noContent(): CustomResponse<Void?> = CustomResponse(
+        fun noContent(): CustomResponse<Void> = CustomResponse(
             status = GlobalExceptionCode.NO_CONTENT.status,
             message = GlobalExceptionCode.NO_CONTENT.message,
             code = GlobalExceptionCode.NO_CONTENT.code,

--- a/gateway/src/main/kotlin/tamago/server/gateway/security/oauth/service/OAuthService.kt
+++ b/gateway/src/main/kotlin/tamago/server/gateway/security/oauth/service/OAuthService.kt
@@ -17,11 +17,7 @@ class OAuthService(
         try {
             kakaoClient.getUserInfo(token)
         } catch (e: FeignException) {
-            if (e.status() == 401) {
-                throw AuthenticationErrorException()
-            } else {
-                throw AuthenticationErrorException()
-            }
+            throw AuthenticationErrorException()
         }
 
     fun getAppleUserInfo(token: String): AppleClientResult {

--- a/gateway/src/main/resources/application-dev-security.yml
+++ b/gateway/src/main/resources/application-dev-security.yml
@@ -1,6 +1,6 @@
 cors:
   allowed-origins:
-    - https://tamago.ummdev.com
+    - https://dev.runtamago.shop
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}

--- a/notification/build.gradle.kts
+++ b/notification/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 dependencies {
     implementation("org.springframework.modulith:spring-modulith-starter-core")
+    implementation("com.google.firebase:firebase-admin:9.7.0")
 }
 
 tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {

--- a/notification/build.gradle.kts
+++ b/notification/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.spring")
+    kotlin("plugin.jpa")
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+}
+
+dependencies {
+    implementation("org.springframework.modulith:spring-modulith-starter-core")
+}
+
+tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
+    enabled = false
+}
+
+tasks.named<Jar>("jar") {
+    enabled = true
+}

--- a/notification/src/main/kotlin/tamago/server/notification/FcmSendRequest.kt
+++ b/notification/src/main/kotlin/tamago/server/notification/FcmSendRequest.kt
@@ -1,0 +1,8 @@
+package tamago.server.notification
+
+data class FcmSendRequest(
+    val fcmToken: String,
+    val title: String,
+    val body: String,
+    val destination: String,
+)

--- a/notification/src/main/kotlin/tamago/server/notification/FcmSendResponse.kt
+++ b/notification/src/main/kotlin/tamago/server/notification/FcmSendResponse.kt
@@ -1,0 +1,8 @@
+package tamago.server.notification
+
+data class FcmSendResponse(
+    val fcmToken: String,
+    val title: String,
+    val body: String,
+    val success: Boolean,
+)

--- a/notification/src/main/kotlin/tamago/server/notification/FirebaseCloudMessageSender.kt
+++ b/notification/src/main/kotlin/tamago/server/notification/FirebaseCloudMessageSender.kt
@@ -1,0 +1,82 @@
+package tamago.server.notification
+
+import com.google.api.core.ApiFuture
+import com.google.firebase.messaging.ApnsConfig
+import com.google.firebase.messaging.Aps
+import com.google.firebase.messaging.BatchResponse
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.MulticastMessage
+import com.google.firebase.messaging.Notification
+import org.springframework.stereotype.Component
+import java.util.concurrent.Future
+
+@Component
+class FirebaseCloudMessageSender(
+    private val firebaseMessaging: FirebaseMessaging,
+) {
+    fun sendAsync(fcmSendRequest: FcmSendRequest): Future<String> = firebaseMessaging.sendAsync(toMessage(fcmSendRequest))
+
+    fun sendAsync(requests: List<FcmSendRequest>): ApiFuture<BatchResponse> {
+        val messages = requests.map { toMessage(it) }
+        return firebaseMessaging.sendEachAsync(messages)
+    }
+
+    private fun toMessage(request: FcmSendRequest): Message =
+        Message
+            .builder()
+            .setToken(request.fcmToken)
+            .setNotification(
+                Notification
+                    .builder()
+                    .setTitle(request.title)
+                    .setBody(request.body)
+                    .build(),
+            ).setApnsConfig(
+                ApnsConfig
+                    .builder()
+                    .putCustomData("destination", request.destination)
+                    .setAps(
+                        Aps
+                            .builder()
+                            .setAlert(request.body)
+                            .setBadge(1)
+                            .setSound("default")
+                            .build(),
+                    ).build(),
+            ).build()
+
+    fun sendEachForMulticastAll(
+        title: String,
+        body: String,
+        destination: String,
+        fcmTokens: List<String>,
+    ): BatchResponse? {
+        val notification =
+            Notification
+                .builder()
+                .setTitle(title)
+                .setBody(body)
+                .build()
+        val message =
+            MulticastMessage
+                .builder()
+                .setNotification(notification)
+                .addAllTokens(fcmTokens)
+                .setApnsConfig(
+                    ApnsConfig
+                        .builder()
+                        .putCustomData("destination", destination)
+                        .setAps(
+                            Aps
+                                .builder()
+                                .setAlert(body)
+                                .setBadge(1)
+                                .setSound("default")
+                                .build(),
+                        ).build(),
+                ).build()
+
+        return firebaseMessaging.sendEachForMulticast(message)
+    }
+}

--- a/notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
+++ b/notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
@@ -1,0 +1,44 @@
+package tamago.server.notification
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.FirebaseMessaging
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
+import java.io.IOException
+
+@Configuration
+@EnableConfigurationProperties(FirebaseProperties::class)
+class FirebaseConfig(
+    private val firebaseProperties: FirebaseProperties,
+) {
+
+    @Bean
+    fun firebaseApp(): FirebaseApp {
+        if (FirebaseApp.getApps().isNotEmpty()) {
+            return FirebaseApp.getInstance()
+        }
+
+        val credentials = try {
+            ClassPathResource(firebaseProperties.credentialsPath).inputStream.use {
+                GoogleCredentials.fromStream(it)
+            }
+        } catch (e: IOException) {
+            throw IllegalStateException("Firebase credentials file not found: ${firebaseProperties.credentialsPath}", e)
+        }
+
+        val options = FirebaseOptions.builder()
+            .setCredentials(credentials)
+            .build()
+
+        return FirebaseApp.initializeApp(options)
+    }
+
+    @Bean
+    fun firebaseMessaging(firebaseApp: FirebaseApp): FirebaseMessaging {
+        return FirebaseMessaging.getInstance(firebaseApp)
+    }
+}

--- a/notification/src/main/kotlin/tamago/server/notification/FirebaseProperties.kt
+++ b/notification/src/main/kotlin/tamago/server/notification/FirebaseProperties.kt
@@ -1,0 +1,8 @@
+package tamago.server.notification
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "fcm")
+data class FirebaseProperties(
+    val credentialsPath: String,
+)

--- a/notification/src/main/resources/fcm.yml
+++ b/notification/src/main/resources/fcm.yml
@@ -1,0 +1,2 @@
+fcm:
+  credentials-path: ${FCM_CREDENTIALS_PATH:firebase-service-account.json}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,3 +17,4 @@ rootProject.name = "tamago-server"
 
 include("core")
 include("gateway")
+include("notification")


### PR DESCRIPTION
## Summary

>- #14 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 타마고 편지 모델링
- Firebase Cloud Message SDK 연동
- 카카오 애플 로그인 이슈 픽스
- 편지 템플릿 생성 및 조회 
- 편지 읽음 처리

## ETC

- FCM 푸시 스케줄링이 후행 작업으로 남아 있음
- 
<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 편지 수신함 조회·읽음 처리 API 및 편지 템플릿 생성(관리자 권한) 추가
  * 사용자 누적 주행 거리·경과 일수 조회 API 추가
  * FCM 전송 기능 및 관련 설정·모듈 추가

* **개선사항**
  * 로그인 응답에 신규 사용자(newUser) 플래그 반영 및 온보딩 기반 판단/토큰 재발급 개선
  * 알림 스케줄 필드 및 매핑 추가
  * 빌드·패키징 설정 및 CORS 도메인 정비

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->