### PR TITLE
feat: 러닝 종료 시 러닝 데이터 저장하고 타마고 몬스터 진화 경험치를 반환하는 API

### DIFF
--- a/tamago-core/build.gradle.kts
+++ b/tamago-core/build.gradle.kts
@@ -48,10 +48,6 @@ flyway {
     locations = arrayOf("filesystem:src/main/resources/db/migration")
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
-
 tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
     enabled = false
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterCommandUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterCommandUseCase.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.monster
+
+import tamago.server.core.common.vo.UserId
+import tamago.server.core.monster.domain.aggregate.OwnedMonster
+
+interface MonsterCommandUseCase {
+    fun initRandomMonster(userId: UserId): OwnedMonster
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterCommandUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterCommandUseCase.kt
@@ -2,7 +2,8 @@ package tamago.server.core.monster
 
 import tamago.server.core.common.vo.UserId
 import tamago.server.core.monster.domain.aggregate.OwnedMonster
+import tamago.server.core.monster.domain.vo.MonsterId
 
 interface MonsterCommandUseCase {
-    fun initRandomMonster(userId: UserId): OwnedMonster
+    fun initMonster(userId: UserId, monsterId: MonsterId): OwnedMonster
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
@@ -12,8 +12,8 @@ class MonsterFacade(
 ) {
     @Transactional
     fun initRandomMonster(userId: UserId): InitMonsterQueryDto {
-        val ownedMonster = monsterCommandUseCase.initRandomMonster(userId)
-        val monster = monsterQueryUseCase.get(ownedMonster.monsterId)
+        val monster = monsterQueryUseCase.getRandomFirstStageMonster()
+        val ownedMonster = monsterCommandUseCase.initMonster(userId, monster.id!!)
 
         return InitMonsterQueryDto(
             ownedMonsterId = ownedMonster.id!!.value,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
@@ -1,0 +1,25 @@
+package tamago.server.core.monster
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import tamago.server.core.common.vo.UserId
+import tamago.server.core.monster.domain.port.inbound.query.InitMonsterQueryDto
+
+@Component
+class MonsterFacade(
+    private val monsterCommandUseCase: MonsterCommandUseCase,
+    private val monsterQueryUseCase: MonsterQueryUseCase,
+) {
+    @Transactional
+    fun initRandomMonster(userId: UserId): InitMonsterQueryDto {
+        val ownedMonster = monsterCommandUseCase.initRandomMonster(userId)
+        val monster = monsterQueryUseCase.get(ownedMonster.monsterId)
+
+        return InitMonsterQueryDto(
+            ownedMonsterId = ownedMonster.id!!.value,
+            monsterId = monster.id!!.value,
+            nickname = monster.nickname,
+            status = ownedMonster.status!!.name,
+        )
+    }
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterQueryUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterQueryUseCase.kt
@@ -1,0 +1,12 @@
+package tamago.server.core.monster
+
+import tamago.server.core.monster.domain.aggregate.Monster
+import tamago.server.core.monster.domain.aggregate.OwnedMonster
+import tamago.server.core.monster.domain.vo.MonsterId
+import tamago.server.core.monster.domain.vo.OwnedMonsterId
+
+interface MonsterQueryUseCase {
+    fun get(id: MonsterId): Monster
+    fun getOwnedMonster(id: OwnedMonsterId): OwnedMonster
+    fun getEvolutionChain(monsterId: MonsterId): List<Monster>
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterQueryUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterQueryUseCase.kt
@@ -9,4 +9,5 @@ interface MonsterQueryUseCase {
     fun get(id: MonsterId): Monster
     fun getOwnedMonster(id: OwnedMonsterId): OwnedMonster
     fun getEvolutionChain(monsterId: MonsterId): List<Monster>
+    fun getRandomFirstStageMonster(): Monster
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterExceptionCode.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterExceptionCode.kt
@@ -1,0 +1,20 @@
+package tamago.server.core.monster.application.exception
+
+import org.springframework.http.HttpStatus
+import tamago.server.core.common.exception.ExceptionCode
+
+enum class MonsterExceptionCode(
+    @JvmField val status: HttpStatus,
+    @JvmField val code: String,
+    @JvmField val message: String,
+) : ExceptionCode {
+    MONSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MONSTER_4040", "몬스터를 찾을 수 없습니다."),
+    OWNED_MONSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MONSTER_4041", "소유한 몬스터를 찾을 수 없습니다."),
+    ;
+
+    override fun getStatus(): HttpStatus = status
+
+    override fun getCode(): String = code
+
+    override fun getMessage(): String = message
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterNotFoundException.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterNotFoundException.kt
@@ -1,0 +1,7 @@
+package tamago.server.core.monster.application.exception
+
+import tamago.server.core.common.exception.BusinessException
+
+class MonsterNotFoundException : BusinessException(
+    MonsterExceptionCode.MONSTER_NOT_FOUND,
+)

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/OwnedMonsterNotFoundException.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/OwnedMonsterNotFoundException.kt
@@ -1,0 +1,7 @@
+package tamago.server.core.monster.application.exception
+
+import tamago.server.core.common.exception.BusinessException
+
+class OwnedMonsterNotFoundException : BusinessException(
+    MonsterExceptionCode.OWNED_MONSTER_NOT_FOUND,
+)

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
@@ -5,21 +5,17 @@ import tamago.server.core.common.vo.UserId
 import tamago.server.core.monster.MonsterCommandUseCase
 import tamago.server.core.monster.domain.aggregate.OwnedMonster
 import tamago.server.core.monster.domain.enum.OwnedMonsterStatus
-import tamago.server.core.monster.domain.port.outbound.MonsterPersistencePort
 import tamago.server.core.monster.domain.port.outbound.OwnedMonsterPersistencePort
+import tamago.server.core.monster.domain.vo.MonsterId
 
 @Service
 class MonsterCommandService(
-    private val monsterPersistencePort: MonsterPersistencePort,
     private val ownedMonsterPersistencePort: OwnedMonsterPersistencePort,
 ) : MonsterCommandUseCase {
 
-    override fun initRandomMonster(userId: UserId): OwnedMonster {
-        val firstStageMonsters = monsterPersistencePort.findAllByPreviousMonsterIdIsNull()
-        val selected = firstStageMonsters.random()
-
+    override fun initMonster(userId: UserId, monsterId: MonsterId): OwnedMonster {
         val ownedMonster = OwnedMonster.create(
-            monsterId = selected.id!!,
+            monsterId = monsterId,
             userId = userId,
             havingXp = 0,
             status = OwnedMonsterStatus.OWNED,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
@@ -1,0 +1,30 @@
+package tamago.server.core.monster.application.service
+
+import org.springframework.stereotype.Service
+import tamago.server.core.common.vo.UserId
+import tamago.server.core.monster.MonsterCommandUseCase
+import tamago.server.core.monster.domain.aggregate.OwnedMonster
+import tamago.server.core.monster.domain.enum.OwnedMonsterStatus
+import tamago.server.core.monster.domain.port.outbound.MonsterPersistencePort
+import tamago.server.core.monster.domain.port.outbound.OwnedMonsterPersistencePort
+
+@Service
+class MonsterCommandService(
+    private val monsterPersistencePort: MonsterPersistencePort,
+    private val ownedMonsterPersistencePort: OwnedMonsterPersistencePort,
+) : MonsterCommandUseCase {
+
+    override fun initRandomMonster(userId: UserId): OwnedMonster {
+        val firstStageMonsters = monsterPersistencePort.findAllByPreviousMonsterIdIsNull()
+        val selected = firstStageMonsters.random()
+
+        val ownedMonster = OwnedMonster.create(
+            monsterId = selected.id!!,
+            userId = userId,
+            havingXp = 0,
+            status = OwnedMonsterStatus.OWNED,
+        )
+
+        return ownedMonsterPersistencePort.save(ownedMonster)
+    }
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
@@ -46,4 +46,10 @@ class MonsterQueryService(
 
         return previousChain.reversed() + current + nextChain
     }
+
+    override fun getRandomFirstStageMonster(): Monster {
+        val firstStageMonsters = monsterPersistencePort.findAllByPreviousMonsterIdIsNull()
+        if (firstStageMonsters.isEmpty()) throw MonsterNotFoundException()
+        return firstStageMonsters.random()
+    }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
@@ -1,0 +1,49 @@
+package tamago.server.core.monster.application.service
+
+import org.springframework.stereotype.Service
+import tamago.server.core.monster.MonsterQueryUseCase
+import tamago.server.core.monster.application.exception.MonsterNotFoundException
+import tamago.server.core.monster.application.exception.OwnedMonsterNotFoundException
+import tamago.server.core.monster.domain.aggregate.Monster
+import tamago.server.core.monster.domain.aggregate.OwnedMonster
+import tamago.server.core.monster.domain.port.outbound.MonsterPersistencePort
+import tamago.server.core.monster.domain.port.outbound.OwnedMonsterPersistencePort
+import tamago.server.core.monster.domain.vo.MonsterId
+import tamago.server.core.monster.domain.vo.OwnedMonsterId
+
+@Service
+class MonsterQueryService(
+    private val monsterPersistencePort: MonsterPersistencePort,
+    private val ownedMonsterPersistencePort: OwnedMonsterPersistencePort,
+) : MonsterQueryUseCase {
+
+    override fun get(id: MonsterId): Monster =
+        monsterPersistencePort.findById(id)
+            ?: throw MonsterNotFoundException()
+
+    override fun getOwnedMonster(id: OwnedMonsterId): OwnedMonster =
+        ownedMonsterPersistencePort.findById(id)
+            ?: throw OwnedMonsterNotFoundException()
+
+    override fun getEvolutionChain(monsterId: MonsterId): List<Monster> {
+        val current = monsterPersistencePort.findById(monsterId) ?: throw MonsterNotFoundException()
+
+        val previousChain = mutableListOf<Monster>()
+        var prevId: MonsterId? = current.previousMonsterId
+        while (prevId != null) {
+            val monster = monsterPersistencePort.findById(prevId) ?: break
+            previousChain.add(monster)
+            prevId = monster.previousMonsterId
+        }
+
+        val nextChain = mutableListOf<Monster>()
+        var nextId: MonsterId? = current.nextMonsterId
+        while (nextId != null) {
+            val monster = monsterPersistencePort.findById(nextId) ?: break
+            nextChain.add(monster)
+            nextId = monster.nextMonsterId
+        }
+
+        return previousChain.reversed() + current + nextChain
+    }
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/Monster.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/Monster.kt
@@ -9,6 +9,7 @@ class Monster(
     val nextMonsterId: MonsterId? = null,
     val nickname: String? = null,
     val evolutionXp: Int? = null,
+    val evolutionPolicy: MonsterEvolutionPolicy? = null,
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null,
     val deletedAt: LocalDateTime? = null,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/Monster.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/Monster.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 
 class Monster(
     val id: MonsterId? = null,
+    val previousMonsterId: MonsterId? = null,
     val nextMonsterId: MonsterId? = null,
     val nickname: String? = null,
     val evolutionXp: Int? = null,
@@ -14,11 +15,13 @@ class Monster(
 ) {
     companion object {
         fun create(
+            previousMonsterId: MonsterId? = null,
             nextMonsterId: MonsterId? = null,
             nickname: String? = null,
             evolutionXp: Int? = null,
         ): Monster {
             return Monster(
+                previousMonsterId = previousMonsterId,
                 nextMonsterId = nextMonsterId,
                 nickname = nickname,
                 evolutionXp = evolutionXp,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/MonsterEvolutionPolicy.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/MonsterEvolutionPolicy.kt
@@ -9,21 +9,28 @@ class MonsterEvolutionPolicy(
     val id: MonsterEvolutionPolicyId? = null,
     val monsterId: MonsterId,
     val ruleType: MonsterRuleType? = null,
-    val ruleValue: Int? = null,
+    val multiplier: Int? = null,
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null,
     val deletedAt: LocalDateTime? = null,
 ) {
+    fun calculateXp(distance: Double): Int {
+        return when (ruleType) {
+            MonsterRuleType.KILOMETER -> (distance * (multiplier ?: 0)).toInt()
+            null -> 0
+        }
+    }
+
     companion object {
         fun create(
             monsterId: MonsterId,
             ruleType: MonsterRuleType? = null,
-            ruleValue: Int? = null,
+            multiplier: Int? = null,
         ): MonsterEvolutionPolicy {
             return MonsterEvolutionPolicy(
                 monsterId = monsterId,
                 ruleType = ruleType,
-                ruleValue = ruleValue,
+                multiplier = multiplier,
             )
         }
     }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/OwnedMonster.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/OwnedMonster.kt
@@ -10,7 +10,7 @@ class OwnedMonster(
     val id: OwnedMonsterId? = null,
     val monsterId: MonsterId,
     val userId: UserId,
-    val earnedXp: Int? = null,
+    val havingXp: Int? = null,
     val status: OwnedMonsterStatus? = null,
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null,
@@ -20,13 +20,13 @@ class OwnedMonster(
         fun create(
             monsterId: MonsterId,
             userId: UserId,
-            earnedXp: Int? = null,
+            havingXp: Int? = null,
             status: OwnedMonsterStatus? = null,
         ): OwnedMonster {
             return OwnedMonster(
                 monsterId = monsterId,
                 userId = userId,
-                earnedXp = earnedXp,
+                havingXp = havingXp,
                 status = status,
             )
         }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/enum/MonsterRuleType.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/enum/MonsterRuleType.kt
@@ -1,5 +1,5 @@
 package tamago.server.core.monster.domain.enum
 
 enum class MonsterRuleType {
-    TOTAL_KM,
+    KILOMETER,
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/inbound/query/InitMonsterQueryDto.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/inbound/query/InitMonsterQueryDto.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.monster.domain.port.inbound.query
+
+data class InitMonsterQueryDto(
+    val ownedMonsterId: Long,
+    val monsterId: Long,
+    val nickname: String?,
+    val status: String,
+)

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/MonsterPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/MonsterPersistencePort.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.monster.domain.port.outbound
+
+import tamago.server.core.monster.domain.aggregate.Monster
+import tamago.server.core.monster.domain.vo.MonsterId
+
+interface MonsterPersistencePort {
+    fun findById(id: MonsterId): Monster?
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/MonsterPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/MonsterPersistencePort.kt
@@ -5,4 +5,5 @@ import tamago.server.core.monster.domain.vo.MonsterId
 
 interface MonsterPersistencePort {
     fun findById(id: MonsterId): Monster?
+    fun findAllByPreviousMonsterIdIsNull(): List<Monster>
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/OwnedMonsterPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/OwnedMonsterPersistencePort.kt
@@ -5,4 +5,5 @@ import tamago.server.core.monster.domain.vo.OwnedMonsterId
 
 interface OwnedMonsterPersistencePort {
     fun findById(id: OwnedMonsterId): OwnedMonster?
+    fun save(ownedMonster: OwnedMonster): OwnedMonster
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/OwnedMonsterPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/OwnedMonsterPersistencePort.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.monster.domain.port.outbound
+
+import tamago.server.core.monster.domain.aggregate.OwnedMonster
+import tamago.server.core.monster.domain.vo.OwnedMonsterId
+
+interface OwnedMonsterPersistencePort {
+    fun findById(id: OwnedMonsterId): OwnedMonster?
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/entity/MonsterEntity.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/entity/MonsterEntity.kt
@@ -22,6 +22,10 @@ class MonsterEntity(
     val id: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "previous_monster_id")
+    val previousMonster: MonsterEntity? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "next_monster_id")
     val nextMonster: MonsterEntity? = null,
 

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/entity/MonsterEntity.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/entity/MonsterEntity.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import tamago.server.core.common.entity.BaseTimeEntity
 
@@ -37,6 +38,6 @@ class MonsterEntity(
     @OneToMany(mappedBy = "monster", cascade = [CascadeType.ALL], orphanRemoval = true)
     val unlockPolicies: MutableList<MonsterUnlockPolicyEntity> = mutableListOf(),
 
-    @OneToMany(mappedBy = "monster", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val evolutionPolicies: MutableList<MonsterEvolutionPolicyEntity> = mutableListOf(),
+    @OneToOne(mappedBy = "monster", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val evolutionPolicy: MonsterEvolutionPolicyEntity? = null,
 ) : BaseTimeEntity()

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/entity/MonsterEvolutionPolicyEntity.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/entity/MonsterEvolutionPolicyEntity.kt
@@ -11,7 +11,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import tamago.server.core.common.entity.BaseTimeEntity
 import tamago.server.core.monster.domain.enum.MonsterRuleType
@@ -24,7 +24,7 @@ class MonsterEvolutionPolicyEntity(
     @Column(name = "monster_evolution_policy_id")
     val id: Long? = null,
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(
         name = "monster_id",
         nullable = false,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/entity/MonsterEvolutionPolicyEntity.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/entity/MonsterEvolutionPolicyEntity.kt
@@ -36,6 +36,6 @@ class MonsterEvolutionPolicyEntity(
     @Column(name = "rule_type")
     val ruleType: MonsterRuleType? = null,
 
-    @Column(name = "rule_value")
-    val ruleValue: Int? = null,
+    @Column(name = "multiplier")
+    val multiplier: Int? = null,
 ) : BaseTimeEntity()

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/entity/OwnedMonsterEntity.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/entity/OwnedMonsterEntity.kt
@@ -35,8 +35,8 @@ class OwnedMonsterEntity(
     @Column(name = "user_id", nullable = false)
     val userId: Long,
 
-    @Column(name = "earned_xp")
-    val earnedXp: Int? = null,
+    @Column(name = "having_xp")
+    val havingXp: Int? = null,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/mapper/MonsterEvolutionPolicyMapper.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/mapper/MonsterEvolutionPolicyMapper.kt
@@ -12,7 +12,7 @@ object MonsterEvolutionPolicyMapper {
             id = domain.id?.value,
             monster = monster,
             ruleType = domain.ruleType,
-            ruleValue = domain.ruleValue,
+            multiplier = domain.multiplier,
         )
     }
 
@@ -23,7 +23,7 @@ object MonsterEvolutionPolicyMapper {
             id = entity.id?.let { MonsterEvolutionPolicyId(it) },
             monsterId = MonsterId(entity.monster.id!!),
             ruleType = entity.ruleType,
-            ruleValue = entity.ruleValue,
+            multiplier = entity.multiplier,
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt,
             deletedAt = entity.deletedAt,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/mapper/MonsterMapper.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/mapper/MonsterMapper.kt
@@ -24,6 +24,7 @@ object MonsterMapper {
             nextMonsterId = entity.nextMonster?.id?.let { MonsterId(it) },
             nickname = entity.nickname,
             evolutionXp = entity.evolutionXp,
+            evolutionPolicy = MonsterEvolutionPolicyMapper.toDomain(entity.evolutionPolicy),
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt,
             deletedAt = entity.deletedAt,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/mapper/MonsterMapper.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/mapper/MonsterMapper.kt
@@ -5,9 +5,10 @@ import tamago.server.core.monster.domain.vo.MonsterId
 import tamago.server.core.monster.infrastructure.entity.MonsterEntity
 
 object MonsterMapper {
-    fun toEntity(monster: Monster, nextMonster: MonsterEntity? = null): MonsterEntity {
+    fun toEntity(monster: Monster, previousMonster: MonsterEntity? = null, nextMonster: MonsterEntity? = null): MonsterEntity {
         return MonsterEntity(
             id = monster.id?.value,
+            previousMonster = previousMonster,
             nextMonster = nextMonster,
             nickname = monster.nickname,
             evolutionXp = monster.evolutionXp,
@@ -19,6 +20,7 @@ object MonsterMapper {
 
         return Monster(
             id = entity.id?.let { MonsterId(it) },
+            previousMonsterId = entity.previousMonster?.id?.let { MonsterId(it) },
             nextMonsterId = entity.nextMonster?.id?.let { MonsterId(it) },
             nickname = entity.nickname,
             evolutionXp = entity.evolutionXp,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/mapper/OwnedMonsterMapper.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/mapper/OwnedMonsterMapper.kt
@@ -13,7 +13,7 @@ object OwnedMonsterMapper {
             id = ownedMonster.id?.value,
             monster = monster,
             userId = ownedMonster.userId.value,
-            earnedXp = ownedMonster.earnedXp,
+            havingXp = ownedMonster.havingXp,
             status = ownedMonster.status,
         )
     }
@@ -25,7 +25,7 @@ object OwnedMonsterMapper {
             id = entity.id?.let { OwnedMonsterId(it) },
             monsterId = MonsterId(entity.monster.id!!),
             userId = UserId(entity.userId),
-            earnedXp = entity.earnedXp,
+            havingXp = entity.havingXp,
             status = entity.status,
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/MonsterJpaRepository.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/MonsterJpaRepository.kt
@@ -1,0 +1,6 @@
+package tamago.server.core.monster.infrastructure.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import tamago.server.core.monster.infrastructure.entity.MonsterEntity
+
+interface MonsterJpaRepository : JpaRepository<MonsterEntity, Long>

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/MonsterJpaRepository.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/MonsterJpaRepository.kt
@@ -3,4 +3,6 @@ package tamago.server.core.monster.infrastructure.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import tamago.server.core.monster.infrastructure.entity.MonsterEntity
 
-interface MonsterJpaRepository : JpaRepository<MonsterEntity, Long>
+interface MonsterJpaRepository : JpaRepository<MonsterEntity, Long> {
+    fun findAllByPreviousMonsterIsNull(): List<MonsterEntity>
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/MonsterPersistenceAdapter.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/MonsterPersistenceAdapter.kt
@@ -13,4 +13,7 @@ class MonsterPersistenceAdapter(
 
     override fun findById(id: MonsterId): Monster? =
         MonsterMapper.toDomain(monsterJpaRepository.findById(id.value).orElse(null))
+
+    override fun findAllByPreviousMonsterIdIsNull(): List<Monster> =
+        monsterJpaRepository.findAllByPreviousMonsterIsNull().mapNotNull { MonsterMapper.toDomain(it) }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/MonsterPersistenceAdapter.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/MonsterPersistenceAdapter.kt
@@ -1,0 +1,16 @@
+package tamago.server.core.monster.infrastructure.repository
+
+import org.springframework.stereotype.Repository
+import tamago.server.core.monster.domain.aggregate.Monster
+import tamago.server.core.monster.domain.port.outbound.MonsterPersistencePort
+import tamago.server.core.monster.domain.vo.MonsterId
+import tamago.server.core.monster.infrastructure.mapper.MonsterMapper
+
+@Repository
+class MonsterPersistenceAdapter(
+    private val monsterJpaRepository: MonsterJpaRepository,
+) : MonsterPersistencePort {
+
+    override fun findById(id: MonsterId): Monster? =
+        MonsterMapper.toDomain(monsterJpaRepository.findById(id.value).orElse(null))
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterJpaRepository.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterJpaRepository.kt
@@ -1,0 +1,6 @@
+package tamago.server.core.monster.infrastructure.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import tamago.server.core.monster.infrastructure.entity.OwnedMonsterEntity
+
+interface OwnedMonsterJpaRepository : JpaRepository<OwnedMonsterEntity, Long>

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterPersistenceAdapter.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterPersistenceAdapter.kt
@@ -9,8 +9,16 @@ import tamago.server.core.monster.infrastructure.mapper.OwnedMonsterMapper
 @Repository
 class OwnedMonsterPersistenceAdapter(
     private val ownedMonsterJpaRepository: OwnedMonsterJpaRepository,
+    private val monsterJpaRepository: MonsterJpaRepository,
 ) : OwnedMonsterPersistencePort {
 
     override fun findById(id: OwnedMonsterId): OwnedMonster? =
         OwnedMonsterMapper.toDomain(ownedMonsterJpaRepository.findById(id.value).orElse(null))
+
+    override fun save(ownedMonster: OwnedMonster): OwnedMonster {
+        val monsterEntity = monsterJpaRepository.findById(ownedMonster.monsterId.value).orElseThrow()
+        val entity = OwnedMonsterMapper.toEntity(ownedMonster, monsterEntity)
+        val saved = ownedMonsterJpaRepository.save(entity)
+        return OwnedMonsterMapper.toDomain(saved)!!
+    }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterPersistenceAdapter.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterPersistenceAdapter.kt
@@ -1,0 +1,16 @@
+package tamago.server.core.monster.infrastructure.repository
+
+import org.springframework.stereotype.Repository
+import tamago.server.core.monster.domain.aggregate.OwnedMonster
+import tamago.server.core.monster.domain.port.outbound.OwnedMonsterPersistencePort
+import tamago.server.core.monster.domain.vo.OwnedMonsterId
+import tamago.server.core.monster.infrastructure.mapper.OwnedMonsterMapper
+
+@Repository
+class OwnedMonsterPersistenceAdapter(
+    private val ownedMonsterJpaRepository: OwnedMonsterJpaRepository,
+) : OwnedMonsterPersistencePort {
+
+    override fun findById(id: OwnedMonsterId): OwnedMonster? =
+        OwnedMonsterMapper.toDomain(ownedMonsterJpaRepository.findById(id.value).orElse(null))
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/ModuleInfo.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/ModuleInfo.kt
@@ -3,6 +3,6 @@ package tamago.server.core.running
 import org.springframework.modulith.ApplicationModule
 import org.springframework.modulith.PackageInfo
 
-@ApplicationModule(allowedDependencies = ["common"])
+@ApplicationModule(allowedDependencies = ["common", "monster"])
 @PackageInfo
 class RunningModuleInfo

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningCommandUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningCommandUseCase.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.running
+
+import tamago.server.core.running.domain.aggregate.Running
+import tamago.server.core.running.domain.port.inbound.command.SaveRunningCommandDto
+
+interface RunningCommandUseCase {
+    fun save(command: SaveRunningCommandDto): Running
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -33,6 +33,7 @@ class RunningFacade(
                     stage = index + 1,
                     monsterId = monster.id!!.value,
                     evolutionXp = monster.evolutionXp,
+                    current = monster.id == ownedMonster.monsterId,
                 )
             },
         )

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -1,0 +1,40 @@
+package tamago.server.core.running
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import tamago.server.core.monster.MonsterQueryUseCase
+import tamago.server.core.running.domain.port.inbound.command.SaveRunningCommandDto
+import tamago.server.core.running.domain.port.inbound.query.RunningFinishQueryDto
+import java.time.Duration
+
+@Component
+class RunningFacade(
+    private val runningCommandUseCase: RunningCommandUseCase,
+    private val monsterQueryUseCase: MonsterQueryUseCase,
+) {
+    @Transactional
+    fun saveRunningData(command: SaveRunningCommandDto): RunningFinishQueryDto {
+        val running = runningCommandUseCase.save(command)
+
+        val ownedMonster = monsterQueryUseCase.getOwnedMonster(command.ownedMonsterId)
+        val evolutionChain = monsterQueryUseCase.getEvolutionChain(ownedMonster.monsterId)
+
+        val elapsedSeconds = Duration.between(command.startedAt, command.finishedAt).seconds.toInt()
+
+        return RunningFinishQueryDto(
+            pace = running.pace?.toInt() ?: 0,
+            cadence = running.cadence ?: 0,
+            elapsedTime = elapsedSeconds,
+            totalCalories = running.calories ?: 0,
+            originXp = ownedMonster.earnedXp ?: 0,
+            earnedXp = running.calories ?: 0,
+            evolutionStages = evolutionChain.mapIndexed { index, monster ->
+                RunningFinishQueryDto.EvolutionStageDto(
+                    stage = index + 1,
+                    monsterId = monster.id!!.value,
+                    evolutionXp = monster.evolutionXp,
+                )
+            },
+        )
+    }
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -26,7 +26,7 @@ class RunningFacade(
             cadence = running.cadence ?: 0,
             elapsedTime = elapsedSeconds,
             totalCalories = running.calories ?: 0,
-            originXp = ownedMonster.earnedXp ?: 0,
+            originXp = ownedMonster.havingXp ?: 0,
             earnedXp = running.calories ?: 0,
             evolutionStages = evolutionChain.mapIndexed { index, monster ->
                 RunningFinishQueryDto.EvolutionStageDto(

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -18,6 +18,7 @@ class RunningFacade(
 
         val ownedMonster = monsterQueryUseCase.getOwnedMonster(command.ownedMonsterId)
         val evolutionChain = monsterQueryUseCase.getEvolutionChain(ownedMonster.monsterId)
+        val currentMonster = evolutionChain.first { it.id == ownedMonster.monsterId }
 
         val elapsedSeconds = Duration.between(command.startedAt, command.finishedAt).seconds.toInt()
 
@@ -27,7 +28,7 @@ class RunningFacade(
             elapsedTime = elapsedSeconds,
             totalCalories = running.calories ?: 0,
             originXp = ownedMonster.havingXp ?: 0,
-            earnedXp = running.calories ?: 0,
+            earnedXp = currentMonster.evolutionPolicy?.calculateXp(command.distance) ?: 0, // TODO: earnedXp 저장
             evolutionStages = evolutionChain.mapIndexed { index, monster ->
                 RunningFinishQueryDto.EvolutionStageDto(
                     stage = index + 1,

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/application/exception/InvalidRunningDataException.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/application/exception/InvalidRunningDataException.kt
@@ -1,0 +1,7 @@
+package tamago.server.core.running.application.exception
+
+import tamago.server.core.common.exception.BusinessException
+
+class InvalidRunningDataException : BusinessException(
+    RunningExceptionCode.INVALID_RUNNING_DATA,
+)

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/application/exception/RunningExceptionCode.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/application/exception/RunningExceptionCode.kt
@@ -1,0 +1,19 @@
+package tamago.server.core.running.application.exception
+
+import org.springframework.http.HttpStatus
+import tamago.server.core.common.exception.ExceptionCode
+
+enum class RunningExceptionCode(
+    @JvmField val status: HttpStatus,
+    @JvmField val code: String,
+    @JvmField val message: String,
+) : ExceptionCode {
+    INVALID_RUNNING_DATA(HttpStatus.BAD_REQUEST, "RUNNING_4000", "러닝 데이터가 유효하지 않습니다."),
+    ;
+
+    override fun getStatus(): HttpStatus = status
+
+    override fun getCode(): String = code
+
+    override fun getMessage(): String = message
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningCommandService.kt
@@ -1,0 +1,35 @@
+package tamago.server.core.running.application.service
+
+import org.springframework.stereotype.Service
+import tamago.server.core.running.RunningCommandUseCase
+import tamago.server.core.running.domain.util.RunningCalculator
+import tamago.server.core.running.domain.aggregate.Running
+import tamago.server.core.running.domain.port.inbound.command.SaveRunningCommandDto
+import tamago.server.core.running.domain.port.outbound.RunningPersistencePort
+
+@Service
+class RunningCommandService(
+    private val runningPersistencePort: RunningPersistencePort,
+) : RunningCommandUseCase {
+
+    override fun save(command: SaveRunningCommandDto): Running {
+        val pace = RunningCalculator.calculatePace(command.distance, command.startedAt, command.finishedAt)
+        val cadence = RunningCalculator.calculateCadence(command.distance, command.startedAt, command.finishedAt)
+        val calories = RunningCalculator.calculateCalories(command.distance, command.weight, command.startedAt, command.finishedAt)
+
+        val running = Running.create(
+            userId = command.userId,
+            ownedMonsterId = command.ownedMonsterId,
+            pace = pace,
+            cadence = cadence,
+            calories = calories,
+            distance = command.distance,
+            elevationGain = command.elevationGain,
+            heartbeat = command.heartbeat,
+            startedAt = command.startedAt,
+            finishedAt = command.finishedAt,
+        )
+
+        return runningPersistencePort.save(running)
+    }
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningCommandService.kt
@@ -2,10 +2,13 @@ package tamago.server.core.running.application.service
 
 import org.springframework.stereotype.Service
 import tamago.server.core.running.RunningCommandUseCase
-import tamago.server.core.running.domain.util.RunningCalculator
+import tamago.server.core.running.application.exception.InvalidRunningDataException
 import tamago.server.core.running.domain.aggregate.Running
 import tamago.server.core.running.domain.port.inbound.command.SaveRunningCommandDto
 import tamago.server.core.running.domain.port.outbound.RunningPersistencePort
+import tamago.server.core.running.domain.util.RunningCalculator.calculateCadence
+import tamago.server.core.running.domain.util.RunningCalculator.calculateCalories
+import tamago.server.core.running.domain.util.RunningCalculator.calculatePace
 
 @Service
 class RunningCommandService(
@@ -13,9 +16,13 @@ class RunningCommandService(
 ) : RunningCommandUseCase {
 
     override fun save(command: SaveRunningCommandDto): Running {
-        val pace = RunningCalculator.calculatePace(command.distance, command.startedAt, command.finishedAt)
-        val cadence = RunningCalculator.calculateCadence(command.distance, command.startedAt, command.finishedAt)
-        val calories = RunningCalculator.calculateCalories(command.distance, command.weight, command.startedAt, command.finishedAt)
+        if (command.distance <= 0 || !command.finishedAt.isAfter(command.startedAt)) {
+            throw InvalidRunningDataException()
+        }
+
+        val pace = calculatePace(command.distance, command.startedAt, command.finishedAt)
+        val cadence = calculateCadence(command.distance, command.startedAt, command.finishedAt)
+        val calories = calculateCalories(command.distance, command.weight, command.startedAt, command.finishedAt)
 
         val running = Running.create(
             userId = command.userId,

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/aggregate/Running.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/aggregate/Running.kt
@@ -1,17 +1,20 @@
 package tamago.server.core.running.domain.aggregate
 
-import tamago.server.core.running.domain.vo.RunningId
 import tamago.server.core.common.vo.UserId
+import tamago.server.core.monster.domain.vo.OwnedMonsterId
+import tamago.server.core.running.domain.vo.RunningId
 import java.time.LocalDateTime
-import java.time.LocalTime
 
 class Running(
     val id: RunningId? = null,
     val userId: UserId,
+    val ownedMonsterId: OwnedMonsterId,
     val pace: Double? = null,
-    val time: LocalTime? = null,
-    val kcal: Int? = null,
-    val kilometre: Double? = null,
+    val cadence: Int? = null,
+    val calories: Int? = null,
+    val distance: Double? = null,
+    val elevationGain: Double? = null,
+    val heartbeat: Int? = null,
     val startedAt: LocalDateTime? = null,
     val finishedAt: LocalDateTime? = null,
     val createdAt: LocalDateTime? = null,
@@ -21,19 +24,25 @@ class Running(
     companion object {
         fun create(
             userId: UserId,
+            ownedMonsterId: OwnedMonsterId,
             pace: Double,
-            time: LocalTime,
-            kcal: Int,
-            kilometre: Double,
+            cadence: Int,
+            calories: Int,
+            distance: Double,
+            elevationGain: Double,
+            heartbeat: Int?,
             startedAt: LocalDateTime,
             finishedAt: LocalDateTime,
         ): Running {
             return Running(
                 userId = userId,
+                ownedMonsterId = ownedMonsterId,
                 pace = pace,
-                time = time,
-                kcal = kcal,
-                kilometre = kilometre,
+                cadence = cadence,
+                calories = calories,
+                distance = distance,
+                elevationGain = elevationGain,
+                heartbeat = heartbeat,
                 startedAt = startedAt,
                 finishedAt = finishedAt,
             )

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/command/SaveRunningCommandDto.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/command/SaveRunningCommandDto.kt
@@ -1,0 +1,16 @@
+package tamago.server.core.running.domain.port.inbound.command
+
+import tamago.server.core.common.vo.UserId
+import tamago.server.core.monster.domain.vo.OwnedMonsterId
+import java.time.LocalDateTime
+
+data class SaveRunningCommandDto(
+    val userId: UserId,
+    val weight: Double,
+    val distance: Double,
+    val elevationGain: Double,
+    val heartbeat: Int?,
+    val startedAt: LocalDateTime,
+    val finishedAt: LocalDateTime,
+    val ownedMonsterId: OwnedMonsterId,
+)

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/RunningFinishQueryDto.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/RunningFinishQueryDto.kt
@@ -13,5 +13,6 @@ data class RunningFinishQueryDto(
         val stage: Int,
         val monsterId: Long,
         val evolutionXp: Int?,
+        val current: Boolean,
     )
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/RunningFinishQueryDto.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/RunningFinishQueryDto.kt
@@ -1,0 +1,17 @@
+package tamago.server.core.running.domain.port.inbound.query
+
+data class RunningFinishQueryDto(
+    val pace: Int,
+    val cadence: Int,
+    val elapsedTime: Int,
+    val totalCalories: Int,
+    val originXp: Int,
+    val earnedXp: Int,
+    val evolutionStages: List<EvolutionStageDto>,
+) {
+    data class EvolutionStageDto(
+        val stage: Int,
+        val monsterId: Long,
+        val evolutionXp: Int?,
+    )
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/outbound/RunningPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/outbound/RunningPersistencePort.kt
@@ -1,0 +1,7 @@
+package tamago.server.core.running.domain.port.outbound
+
+import tamago.server.core.running.domain.aggregate.Running
+
+interface RunningPersistencePort {
+    fun save(running: Running): Running
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/util/RunningCalculator.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/util/RunningCalculator.kt
@@ -2,31 +2,41 @@ package tamago.server.core.running.domain.util
 
 import java.time.Duration
 import java.time.LocalDateTime
+import tamago.server.core.running.application.exception.InvalidRunningDataException
 
 object RunningCalculator {
 
+    private fun elapsedSeconds(startedAt: LocalDateTime, finishedAt: LocalDateTime): Long {
+        val seconds = Duration.between(startedAt, finishedAt).seconds
+        if (seconds <= 0) throw InvalidRunningDataException()
+        return seconds
+    }
+
+    private fun validateDistance(distanceKm: Double) {
+        if (distanceKm <= 0) throw InvalidRunningDataException()
+    }
+
     fun calculatePace(distanceKm: Double, startedAt: LocalDateTime, finishedAt: LocalDateTime): Double {
-        val elapsedSeconds = Duration.between(startedAt, finishedAt).seconds
-        return if (distanceKm > 0) elapsedSeconds.toDouble() / distanceKm else 0.0
+        validateDistance(distanceKm)
+        return elapsedSeconds(startedAt, finishedAt).toDouble() / distanceKm
     }
 
     fun calculateCadence(distanceKm: Double, startedAt: LocalDateTime, finishedAt: LocalDateTime): Int {
-        val elapsedSeconds = Duration.between(startedAt, finishedAt).seconds
-        val hours = elapsedSeconds / 3600.0
-        val speedKmh = if (hours > 0) distanceKm / hours else 0.0
-        val stepsPerMinute = when {
+        validateDistance(distanceKm)
+        val hours = elapsedSeconds(startedAt, finishedAt) / 3600.0
+        val speedKmh = distanceKm / hours
+        return when {
             speedKmh < 8.0 -> 155
             speedKmh < 10.0 -> 165
             speedKmh < 12.0 -> 175
             else -> 185
         }
-        return stepsPerMinute
     }
 
     fun calculateCalories(distanceKm: Double, weight: Double, startedAt: LocalDateTime, finishedAt: LocalDateTime): Int {
-        val elapsedSeconds = Duration.between(startedAt, finishedAt).seconds
-        val hours = elapsedSeconds / 3600.0
-        val speedKmh = if (hours > 0) distanceKm / hours else 0.0
+        validateDistance(distanceKm)
+        val hours = elapsedSeconds(startedAt, finishedAt) / 3600.0
+        val speedKmh = distanceKm / hours
         val met = when {
             speedKmh < 8.0 -> 8.3
             speedKmh < 10.0 -> 9.8

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/util/RunningCalculator.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/util/RunningCalculator.kt
@@ -1,0 +1,38 @@
+package tamago.server.core.running.domain.util
+
+import java.time.Duration
+import java.time.LocalDateTime
+
+object RunningCalculator {
+
+    fun calculatePace(distanceKm: Double, startedAt: LocalDateTime, finishedAt: LocalDateTime): Double {
+        val elapsedSeconds = Duration.between(startedAt, finishedAt).seconds
+        return if (distanceKm > 0) elapsedSeconds.toDouble() / distanceKm else 0.0
+    }
+
+    fun calculateCadence(distanceKm: Double, startedAt: LocalDateTime, finishedAt: LocalDateTime): Int {
+        val elapsedSeconds = Duration.between(startedAt, finishedAt).seconds
+        val hours = elapsedSeconds / 3600.0
+        val speedKmh = if (hours > 0) distanceKm / hours else 0.0
+        val stepsPerMinute = when {
+            speedKmh < 8.0 -> 155
+            speedKmh < 10.0 -> 165
+            speedKmh < 12.0 -> 175
+            else -> 185
+        }
+        return stepsPerMinute
+    }
+
+    fun calculateCalories(distanceKm: Double, weight: Double, startedAt: LocalDateTime, finishedAt: LocalDateTime): Int {
+        val elapsedSeconds = Duration.between(startedAt, finishedAt).seconds
+        val hours = elapsedSeconds / 3600.0
+        val speedKmh = if (hours > 0) distanceKm / hours else 0.0
+        val met = when {
+            speedKmh < 8.0 -> 8.3
+            speedKmh < 10.0 -> 9.8
+            speedKmh < 12.0 -> 11.0
+            else -> 12.8
+        }
+        return (met * weight * hours).toInt()
+    }
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/entity/RunningEntity.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/entity/RunningEntity.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import tamago.server.core.common.entity.BaseTimeEntity
 import java.time.LocalDateTime
-import java.time.LocalTime
 
 @Entity
 @Table(name = "t_running")
@@ -18,18 +17,26 @@ class RunningEntity(
     @Column(name = "running_id")
     val id: Long? = null,
 
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+
+    @Column(name = "owned_monster_id", nullable = false)
+    val ownedMonsterId: Long,
+
     val pace: Double? = null,
 
-    val time: LocalTime? = null,
+    val cadence: Int? = null,
 
-    val kcal: Int? = null,
+    val calories: Int? = null,
 
-    val kilometre: Double? = null,
+    val distance: Double? = null,
+
+    @Column(name = "elevation_gain")
+    val elevationGain: Double? = null,
+
+    val heartbeat: Int? = null,
 
     val startedAt: LocalDateTime? = null,
 
     val finishedAt: LocalDateTime? = null,
-
-    @Column(name = "user_id", nullable = false)
-    val userId: Long,
 ) : BaseTimeEntity()

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/mapper/RunningMapper.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/mapper/RunningMapper.kt
@@ -1,21 +1,25 @@
 package tamago.server.core.running.infrastructure.mapper
 
+import tamago.server.core.common.vo.UserId
+import tamago.server.core.monster.domain.vo.OwnedMonsterId
 import tamago.server.core.running.domain.aggregate.Running
 import tamago.server.core.running.domain.vo.RunningId
 import tamago.server.core.running.infrastructure.entity.RunningEntity
-import tamago.server.core.common.vo.UserId
 
 object RunningMapper {
     fun toEntity(running: Running): RunningEntity {
         return RunningEntity(
             id = running.id?.value,
+            userId = running.userId.value,
+            ownedMonsterId = running.ownedMonsterId.value,
             pace = running.pace,
-            time = running.time,
-            kcal = running.kcal,
-            kilometre = running.kilometre,
+            cadence = running.cadence,
+            calories = running.calories,
+            distance = running.distance,
+            elevationGain = running.elevationGain,
+            heartbeat = running.heartbeat,
             startedAt = running.startedAt,
             finishedAt = running.finishedAt,
-            userId = running.userId.value,
         )
     }
 
@@ -25,10 +29,13 @@ object RunningMapper {
         return Running(
             id = entity.id?.let { RunningId(it) },
             userId = UserId(entity.userId),
+            ownedMonsterId = OwnedMonsterId(entity.ownedMonsterId),
             pace = entity.pace,
-            time = entity.time,
-            kcal = entity.kcal,
-            kilometre = entity.kilometre,
+            cadence = entity.cadence,
+            calories = entity.calories,
+            distance = entity.distance,
+            elevationGain = entity.elevationGain,
+            heartbeat = entity.heartbeat,
             startedAt = entity.startedAt,
             finishedAt = entity.finishedAt,
             createdAt = entity.createdAt,

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/repository/RunningJpaRepository.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/repository/RunningJpaRepository.kt
@@ -1,0 +1,6 @@
+package tamago.server.core.running.infrastructure.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import tamago.server.core.running.infrastructure.entity.RunningEntity
+
+interface RunningJpaRepository : JpaRepository<RunningEntity, Long>

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/repository/RunningPersistenceAdapter.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/repository/RunningPersistenceAdapter.kt
@@ -1,0 +1,15 @@
+package tamago.server.core.running.infrastructure.repository
+
+import org.springframework.stereotype.Repository
+import tamago.server.core.running.domain.aggregate.Running
+import tamago.server.core.running.domain.port.outbound.RunningPersistencePort
+import tamago.server.core.running.infrastructure.mapper.RunningMapper
+
+@Repository
+class RunningPersistenceAdapter(
+    private val runningJpaRepository: RunningJpaRepository,
+) : RunningPersistencePort {
+
+    override fun save(running: Running): Running =
+        RunningMapper.toDomain(runningJpaRepository.save(RunningMapper.toEntity(running)))!!
+}

--- a/tamago-core/src/main/resources/db/migration/V10__rename_rule_value_to_multiplier_and_rule_type_update.sql
+++ b/tamago-core/src/main/resources/db/migration/V10__rename_rule_value_to_multiplier_and_rule_type_update.sql
@@ -1,0 +1,3 @@
+ALTER TABLE t_monster_evolution_policy CHANGE COLUMN rule_value multiplier INT;
+
+UPDATE t_monster_evolution_policy SET rule_type = 'KILOMETER' WHERE rule_type = 'TOTAL_KM';

--- a/tamago-core/src/main/resources/db/migration/V10__rename_rule_value_to_multiplier_and_rule_type_update.sql
+++ b/tamago-core/src/main/resources/db/migration/V10__rename_rule_value_to_multiplier_and_rule_type_update.sql
@@ -1,3 +1,6 @@
 ALTER TABLE t_monster_evolution_policy CHANGE COLUMN rule_value multiplier INT;
 
+ALTER TABLE t_monster_evolution_policy MODIFY COLUMN rule_type ENUM('TOTAL_KM', 'KILOMETER') NULL;
 UPDATE t_monster_evolution_policy SET rule_type = 'KILOMETER' WHERE rule_type = 'TOTAL_KM';
+
+ALTER TABLE t_owned_monsters CHANGE COLUMN earned_xp having_xp INT;

--- a/tamago-core/src/main/resources/db/migration/V11__update_unlock_policy_rule_type_to_kilometer.sql
+++ b/tamago-core/src/main/resources/db/migration/V11__update_unlock_policy_rule_type_to_kilometer.sql
@@ -1,0 +1,4 @@
+-- t_monster_unlock_policy의 rule_type ENUM에 KILOMETER 추가 후 TOTAL_KM 데이터 변환
+ALTER TABLE t_monster_unlock_policy MODIFY COLUMN rule_type ENUM('TOTAL_KM', 'KILOMETER') NULL;
+UPDATE t_monster_unlock_policy SET rule_type = 'KILOMETER' WHERE rule_type = 'TOTAL_KM';
+ALTER TABLE t_monster_unlock_policy MODIFY COLUMN rule_type ENUM('KILOMETER') NULL;

--- a/tamago-core/src/main/resources/db/migration/V8__alter_t_running_match_request_fields.sql
+++ b/tamago-core/src/main/resources/db/migration/V8__alter_t_running_match_request_fields.sql
@@ -1,0 +1,7 @@
+ALTER TABLE t_running CHANGE COLUMN kilometre distance DOUBLE;
+ALTER TABLE t_running ADD COLUMN cadence INT AFTER pace;
+ALTER TABLE t_running CHANGE COLUMN kcal calories INT;
+ALTER TABLE t_running DROP COLUMN time;
+ALTER TABLE t_running ADD COLUMN elevation_gain DOUBLE AFTER distance;
+ALTER TABLE t_running ADD COLUMN heartbeat INT AFTER elevation_gain;
+ALTER TABLE t_running ADD COLUMN owned_monster_id BIGINT NOT NULL AFTER user_id;

--- a/tamago-core/src/main/resources/db/migration/V9__add_previous_monster_id_to_monsters.sql
+++ b/tamago-core/src/main/resources/db/migration/V9__add_previous_monster_id_to_monsters.sql
@@ -1,0 +1,1 @@
+ALTER TABLE t_monsters ADD COLUMN previous_monster_id BIGINT AFTER monster_id;

--- a/tamago-core/src/main/resources/db/seed/R__monster_seed.sql
+++ b/tamago-core/src/main/resources/db/seed/R__monster_seed.sql
@@ -1,39 +1,75 @@
 -- ==============================================
--- Monster 시드 데이터 (4단계 진화 체인 1세트)
+-- 테스트 시드 데이터 (유저, 몬스터, 소유 몬스터, 진화 정책)
 -- Repeatable migration: 내용 변경 시 자동 재실행
 -- ==============================================
 
-DELETE FROM t_monster_evolution_policy WHERE monster_id IN (1, 2, 3, 4);
-DELETE FROM t_monsters WHERE monster_id IN (1, 2, 3, 4);
-
--- 1단계: 알 → 2단계로 진화
-INSERT INTO t_monsters (monster_id, previous_monster_id, next_monster_id, nickname, evolution_xp, created_at, updated_at)
-VALUES (1, NULL, 2, '타마알', 100, NOW(), NOW());
-
--- 2단계: 아기 → 3단계로 진화
-INSERT INTO t_monsters (monster_id, previous_monster_id, next_monster_id, nickname, evolution_xp, created_at, updated_at)
-VALUES (2, 1, 3, '타마베이비', 300, NOW(), NOW());
-
--- 3단계: 성장기 → 4단계로 진화
-INSERT INTO t_monsters (monster_id, previous_monster_id, next_monster_id, nickname, evolution_xp, created_at, updated_at)
-VALUES (3, 2, 4, '타마러너', 700, NOW(), NOW());
-
--- 4단계: 최종 진화 (next 없음)
-INSERT INTO t_monsters (monster_id, previous_monster_id, next_monster_id, nickname, evolution_xp, created_at, updated_at)
-VALUES (4, 3, NULL, '타마히어로', NULL, NOW(), NOW());
+-- 기존 시드 데이터 정리
+DELETE FROM t_monster_evolution_policy WHERE monster_id IN (SELECT monster_id FROM t_monsters WHERE nickname IN ('타마알', '타마베이비', '타마러너', '타마히어로'));
+DELETE FROM t_owned_monsters WHERE user_id IN (SELECT id FROM t_users WHERE nickname IN ('테스트유저1', '테스트유저2'));
+DELETE FROM t_user_auth WHERE user_id IN (SELECT id FROM t_users WHERE nickname IN ('테스트유저1', '테스트유저2'));
+DELETE FROM t_monsters WHERE nickname IN ('타마알', '타마베이비', '타마러너', '타마히어로');
+DELETE FROM t_users WHERE nickname IN ('테스트유저1', '테스트유저2');
 
 -- ==============================================
--- Monster 진화 정책 (KILOMETER 기준)
+-- 테스트 유저
 -- ==============================================
 
--- 1단계 → 2단계: 누적 10km 달성 시 진화
-INSERT INTO t_monster_evolution_policy (monster_id, rule_type, multiplier, created_at, updated_at)
-VALUES (1, 'KILOMETER', 10, NOW(), NOW());
+INSERT INTO t_users (nickname, role, goal_kilo, total_kilo, weight, created_at, updated_at)
+VALUES ('테스트유저1', 'USER', 10, 25.5, 65.0, NOW(), NOW());
 
--- 2단계 → 3단계: 누적 50km 달성 시 진화
-INSERT INTO t_monster_evolution_policy (monster_id, rule_type, multiplier, created_at, updated_at)
-VALUES (2, 'KILOMETER', 50, NOW(), NOW());
+INSERT INTO t_users (nickname, role, goal_kilo, total_kilo, weight, created_at, updated_at)
+VALUES ('테스트유저2', 'USER', 5, 0.0, 70.0, NOW(), NOW());
 
--- 3단계 → 4단계: 누적 150km 달성 시 진화
+-- 유저 인증 정보 (카카오 OAuth)
+INSERT INTO t_user_auth (user_id, email, provider, external_id)
+VALUES ((SELECT id FROM t_users WHERE nickname = '테스트유저1'), 'test1@test.com', 'KAKAO', 'kakao_test_001');
+
+INSERT INTO t_user_auth (user_id, email, provider, external_id)
+VALUES ((SELECT id FROM t_users WHERE nickname = '테스트유저2'), 'test2@test.com', 'KAKAO', 'kakao_test_002');
+
+-- ==============================================
+-- 몬스터 (4단계 진화 체인)
+-- ==============================================
+
+INSERT INTO t_monsters (nickname, evolution_xp, created_at, updated_at)
+VALUES ('타마알', 100, NOW(), NOW());
+
+INSERT INTO t_monsters (nickname, evolution_xp, created_at, updated_at)
+VALUES ('타마베이비', 300, NOW(), NOW());
+
+INSERT INTO t_monsters (nickname, evolution_xp, created_at, updated_at)
+VALUES ('타마러너', 700, NOW(), NOW());
+
+INSERT INTO t_monsters (nickname, evolution_xp, created_at, updated_at)
+VALUES ('타마히어로', NULL, NOW(), NOW());
+
+-- 진화 체인 연결
+UPDATE t_monsters SET next_monster_id = (SELECT m.monster_id FROM (SELECT monster_id FROM t_monsters WHERE nickname = '타마베이비') m) WHERE nickname = '타마알';
+UPDATE t_monsters SET previous_monster_id = (SELECT m.monster_id FROM (SELECT monster_id FROM t_monsters WHERE nickname = '타마알') m), next_monster_id = (SELECT m.monster_id FROM (SELECT monster_id FROM t_monsters WHERE nickname = '타마러너') m) WHERE nickname = '타마베이비';
+UPDATE t_monsters SET previous_monster_id = (SELECT m.monster_id FROM (SELECT monster_id FROM t_monsters WHERE nickname = '타마베이비') m), next_monster_id = (SELECT m.monster_id FROM (SELECT monster_id FROM t_monsters WHERE nickname = '타마히어로') m) WHERE nickname = '타마러너';
+UPDATE t_monsters SET previous_monster_id = (SELECT m.monster_id FROM (SELECT monster_id FROM t_monsters WHERE nickname = '타마러너') m) WHERE nickname = '타마히어로';
+
+-- ==============================================
+-- 소유 몬스터
+-- ==============================================
+
+-- 유저1: 1단계 몬스터 소유 중 (XP 50 보유, 진화 중)
+INSERT INTO t_owned_monsters (monster_id, user_id, having_xp, status, created_at, updated_at)
+VALUES ((SELECT monster_id FROM t_monsters WHERE nickname = '타마알'), (SELECT id FROM t_users WHERE nickname = '테스트유저1'), 50, 'OWNED', NOW(), NOW());
+
+-- 유저2: 1단계 몬스터 소유 (XP 0, 시작)
+INSERT INTO t_owned_monsters (monster_id, user_id, having_xp, status, created_at, updated_at)
+VALUES ((SELECT monster_id FROM t_monsters WHERE nickname = '타마알'), (SELECT id FROM t_users WHERE nickname = '테스트유저2'), 0, 'OWNED', NOW(), NOW());
+
+-- ==============================================
+-- 몬스터 진화 정책 (KILOMETER 기준, multiplier = km당 XP 배율)
+-- ==============================================
+
 INSERT INTO t_monster_evolution_policy (monster_id, rule_type, multiplier, created_at, updated_at)
-VALUES (3, 'KILOMETER', 150, NOW(), NOW());
+VALUES ((SELECT monster_id FROM t_monsters WHERE nickname = '타마알'), 'KILOMETER', 10, NOW(), NOW());
+
+INSERT INTO t_monster_evolution_policy (monster_id, rule_type, multiplier, created_at, updated_at)
+VALUES ((SELECT monster_id FROM t_monsters WHERE nickname = '타마베이비'), 'KILOMETER', 50, NOW(), NOW());
+
+INSERT INTO t_monster_evolution_policy (monster_id, rule_type, multiplier, created_at, updated_at)
+VALUES ((SELECT monster_id FROM t_monsters WHERE nickname = '타마러너'), 'KILOMETER', 150, NOW(), NOW());

--- a/tamago-core/src/main/resources/db/seed/R__monster_seed.sql
+++ b/tamago-core/src/main/resources/db/seed/R__monster_seed.sql
@@ -1,31 +1,11 @@
 -- ==============================================
--- 테스트 시드 데이터 (유저, 몬스터, 소유 몬스터, 진화 정책)
+-- 몬스터 시드 데이터 (몬스터 정의 + 진화 정책)
 -- Repeatable migration: 내용 변경 시 자동 재실행
 -- ==============================================
 
 -- 기존 시드 데이터 정리
 DELETE FROM t_monster_evolution_policy WHERE monster_id IN (SELECT monster_id FROM t_monsters WHERE nickname IN ('타마알', '타마베이비', '타마러너', '타마히어로'));
-DELETE FROM t_owned_monsters WHERE user_id IN (SELECT id FROM t_users WHERE nickname IN ('테스트유저1', '테스트유저2'));
-DELETE FROM t_user_auth WHERE user_id IN (SELECT id FROM t_users WHERE nickname IN ('테스트유저1', '테스트유저2'));
 DELETE FROM t_monsters WHERE nickname IN ('타마알', '타마베이비', '타마러너', '타마히어로');
-DELETE FROM t_users WHERE nickname IN ('테스트유저1', '테스트유저2');
-
--- ==============================================
--- 테스트 유저
--- ==============================================
-
-INSERT INTO t_users (nickname, role, goal_kilo, total_kilo, weight, created_at, updated_at)
-VALUES ('테스트유저1', 'USER', 10, 25.5, 65.0, NOW(), NOW());
-
-INSERT INTO t_users (nickname, role, goal_kilo, total_kilo, weight, created_at, updated_at)
-VALUES ('테스트유저2', 'USER', 5, 0.0, 70.0, NOW(), NOW());
-
--- 유저 인증 정보 (카카오 OAuth)
-INSERT INTO t_user_auth (user_id, email, provider, external_id)
-VALUES ((SELECT id FROM t_users WHERE nickname = '테스트유저1'), 'test1@test.com', 'KAKAO', 'kakao_test_001');
-
-INSERT INTO t_user_auth (user_id, email, provider, external_id)
-VALUES ((SELECT id FROM t_users WHERE nickname = '테스트유저2'), 'test2@test.com', 'KAKAO', 'kakao_test_002');
 
 -- ==============================================
 -- 몬스터 (4단계 진화 체인)
@@ -48,18 +28,6 @@ UPDATE t_monsters SET next_monster_id = (SELECT m.monster_id FROM (SELECT monste
 UPDATE t_monsters SET previous_monster_id = (SELECT m.monster_id FROM (SELECT monster_id FROM t_monsters WHERE nickname = '타마알') m), next_monster_id = (SELECT m.monster_id FROM (SELECT monster_id FROM t_monsters WHERE nickname = '타마러너') m) WHERE nickname = '타마베이비';
 UPDATE t_monsters SET previous_monster_id = (SELECT m.monster_id FROM (SELECT monster_id FROM t_monsters WHERE nickname = '타마베이비') m), next_monster_id = (SELECT m.monster_id FROM (SELECT monster_id FROM t_monsters WHERE nickname = '타마히어로') m) WHERE nickname = '타마러너';
 UPDATE t_monsters SET previous_monster_id = (SELECT m.monster_id FROM (SELECT monster_id FROM t_monsters WHERE nickname = '타마러너') m) WHERE nickname = '타마히어로';
-
--- ==============================================
--- 소유 몬스터
--- ==============================================
-
--- 유저1: 1단계 몬스터 소유 중 (XP 50 보유, 진화 중)
-INSERT INTO t_owned_monsters (monster_id, user_id, having_xp, status, created_at, updated_at)
-VALUES ((SELECT monster_id FROM t_monsters WHERE nickname = '타마알'), (SELECT id FROM t_users WHERE nickname = '테스트유저1'), 50, 'OWNED', NOW(), NOW());
-
--- 유저2: 1단계 몬스터 소유 (XP 0, 시작)
-INSERT INTO t_owned_monsters (monster_id, user_id, having_xp, status, created_at, updated_at)
-VALUES ((SELECT monster_id FROM t_monsters WHERE nickname = '타마알'), (SELECT id FROM t_users WHERE nickname = '테스트유저2'), 0, 'OWNED', NOW(), NOW());
 
 -- ==============================================
 -- 몬스터 진화 정책 (KILOMETER 기준, multiplier = km당 XP 배율)

--- a/tamago-core/src/main/resources/db/seed/R__monster_seed.sql
+++ b/tamago-core/src/main/resources/db/seed/R__monster_seed.sql
@@ -1,0 +1,39 @@
+-- ==============================================
+-- Monster 시드 데이터 (4단계 진화 체인 1세트)
+-- Repeatable migration: 내용 변경 시 자동 재실행
+-- ==============================================
+
+DELETE FROM t_monster_evolution_policy WHERE monster_id IN (1, 2, 3, 4);
+DELETE FROM t_monsters WHERE monster_id IN (1, 2, 3, 4);
+
+-- 1단계: 알 → 2단계로 진화
+INSERT INTO t_monsters (monster_id, previous_monster_id, next_monster_id, nickname, evolution_xp, created_at, updated_at)
+VALUES (1, NULL, 2, '타마알', 100, NOW(), NOW());
+
+-- 2단계: 아기 → 3단계로 진화
+INSERT INTO t_monsters (monster_id, previous_monster_id, next_monster_id, nickname, evolution_xp, created_at, updated_at)
+VALUES (2, 1, 3, '타마베이비', 300, NOW(), NOW());
+
+-- 3단계: 성장기 → 4단계로 진화
+INSERT INTO t_monsters (monster_id, previous_monster_id, next_monster_id, nickname, evolution_xp, created_at, updated_at)
+VALUES (3, 2, 4, '타마러너', 700, NOW(), NOW());
+
+-- 4단계: 최종 진화 (next 없음)
+INSERT INTO t_monsters (monster_id, previous_monster_id, next_monster_id, nickname, evolution_xp, created_at, updated_at)
+VALUES (4, 3, NULL, '타마히어로', NULL, NOW(), NOW());
+
+-- ==============================================
+-- Monster 진화 정책 (KILOMETER 기준)
+-- ==============================================
+
+-- 1단계 → 2단계: 누적 10km 달성 시 진화
+INSERT INTO t_monster_evolution_policy (monster_id, rule_type, multiplier, created_at, updated_at)
+VALUES (1, 'KILOMETER', 10, NOW(), NOW());
+
+-- 2단계 → 3단계: 누적 50km 달성 시 진화
+INSERT INTO t_monster_evolution_policy (monster_id, rule_type, multiplier, created_at, updated_at)
+VALUES (2, 'KILOMETER', 50, NOW(), NOW());
+
+-- 3단계 → 4단계: 누적 150km 달성 시 진화
+INSERT INTO t_monster_evolution_policy (monster_id, rule_type, multiplier, created_at, updated_at)
+VALUES (3, 'KILOMETER', 150, NOW(), NOW());

--- a/tamago-core/src/main/resources/flyway.yml
+++ b/tamago-core/src/main/resources/flyway.yml
@@ -15,8 +15,20 @@ logging:
 spring:
   config:
     activate:
-      on-profile: dev, prod
+      on-profile: dev
 
   flyway:
     clean-disabled: true
     validate-on-migrate: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  flyway:
+    clean-disabled: true
+    validate-on-migrate: true
+    locations:
+      - classpath:db/migration

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/common/configuration/SwaggerConfig.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/common/configuration/SwaggerConfig.kt
@@ -33,6 +33,12 @@ class SwaggerConfig(
             .components(components())
 
     @Bean
+    fun tagSortCustomizer(): OpenApiCustomizer =
+        OpenApiCustomizer { openApi ->
+            openApi.tags?.sortBy { it.name }
+        }
+
+    @Bean
     fun remove4xxContentCustomizer(): OpenApiCustomizer =
         OpenApiCustomizer { openApi ->
             openApi

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/common/response/CustomResponse.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/common/response/CustomResponse.kt
@@ -48,10 +48,13 @@ data class CustomResponse<T>(
             data = data
         )
 
-        fun <T> created(): CustomResponse<T> = CustomResponse(
+        fun <T> created(): CustomResponse<T> = created(null)
+
+        fun <T> created(data: T?): CustomResponse<T> = CustomResponse(
             status = GlobalExceptionCode.CREATED.status,
             message = GlobalExceptionCode.CREATED.message,
             code = GlobalExceptionCode.CREATED.code,
+            data = data,
         )
 
         fun noContent(): CustomResponse<Void> = CustomResponse(

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/auth/v1/api/TestAuthApi.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/auth/v1/api/TestAuthApi.kt
@@ -7,7 +7,7 @@ import tamago.server.gateway.presentation.auth.v1.request.SignupRequest
 import tamago.server.gateway.presentation.auth.v1.response.LoginResponse
 import tamago.server.gateway.common.response.CustomResponse
 
-@Tag(name = "Test Auth API", description = "테스트용 인증 API (local, dev 환경에서만 사용 가능)")
+@Tag(name = "\uD83E\uDDEA Test Auth API", description = "테스트용 인증 API (local, dev 환경에서만 사용 가능)")
 interface TestAuthApi {
     @Operation(summary = "테스트 유저 회원가입", description = "이메일과 비밀번호로 테스트 유저를 생성 합니다.")
     fun signup(request: SignupRequest): CustomResponse<Void>

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/api/LetterApi.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/api/LetterApi.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import tamago.server.core.letter.domain.vo.ReceivedLetterId
 import tamago.server.core.user.domain.aggregate.User
-import tamago.server.gateway.presentation.letter.v1.request.LetterCreate
+import tamago.server.gateway.presentation.letter.v1.request.LetterCreateRequest
 import tamago.server.gateway.presentation.letter.v1.response.LetterResponse
 import tamago.server.gateway.common.response.CustomResponse
 
@@ -19,5 +19,5 @@ interface LetterApi {
 
     @Hidden
     @Operation(summary = "편지 템플릿 데이터 삽입", description = "편지 템플릿에 데이터를 삽입하여 편지 내용을 생성합니다.")
-    fun createTemplate(request: LetterCreate): CustomResponse<Void>
+    fun createTemplate(request: LetterCreateRequest): CustomResponse<Void>
 }

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/controller/LetterController.kt
@@ -11,7 +11,7 @@ import tamago.server.core.letter.LetterQueryUseCase
 import tamago.server.core.letter.domain.vo.ReceivedLetterId
 import tamago.server.core.user.domain.aggregate.User
 import tamago.server.gateway.presentation.letter.v1.api.LetterApi
-import tamago.server.gateway.presentation.letter.v1.request.LetterCreate
+import tamago.server.gateway.presentation.letter.v1.request.LetterCreateRequest
 import tamago.server.gateway.presentation.letter.v1.response.LetterResponse
 import tamago.server.gateway.common.response.CustomResponse
 import tamago.server.gateway.common.annotation.CurrentUser
@@ -52,7 +52,7 @@ class LetterController(
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/api/v1/letters")
-    override fun createTemplate(@RequestBody @Valid request: LetterCreate): CustomResponse<Void> {
+    override fun createTemplate(@RequestBody @Valid request: LetterCreateRequest): CustomResponse<Void> {
         letterCommandUseCase.createTemplate(
             title = request.title,
             content = request.content,

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/request/LetterCreateRequest.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/letter/v1/request/LetterCreateRequest.kt
@@ -3,7 +3,7 @@ package tamago.server.gateway.presentation.letter.v1.request
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 
-data class LetterCreate(
+data class LetterCreateRequest(
     @field:Schema(description = "편지 제목", example = "템플릿 제목", requiredMode = Schema.RequiredMode.REQUIRED)
     @field:NotBlank(message = "제목은 필수입니다.")
     val title: String,

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/api/InitMonsterApi.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/api/InitMonsterApi.kt
@@ -1,0 +1,13 @@
+package tamago.server.gateway.presentation.monster.v1.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import tamago.server.core.user.domain.aggregate.User
+import tamago.server.gateway.common.response.CustomResponse
+import tamago.server.gateway.presentation.monster.v1.response.InitMonsterResponse
+
+@Tag(name = "Init Monster API", description = "테스트용 몬스터 초기화 API (local, dev 환경에서만 사용 가능)")
+interface InitMonsterApi {
+    @Operation(summary = "랜덤 1단계 몬스터 초기화", description = "인증된 유저에게 랜덤 1단계 몬스터를 소유시킵니다.")
+    fun initRandomMonster(user: User): CustomResponse<InitMonsterResponse>
+}

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/api/InitMonsterApi.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/api/InitMonsterApi.kt
@@ -6,7 +6,7 @@ import tamago.server.core.user.domain.aggregate.User
 import tamago.server.gateway.common.response.CustomResponse
 import tamago.server.gateway.presentation.monster.v1.response.InitMonsterResponse
 
-@Tag(name = "Init Monster API", description = "테스트용 몬스터 초기화 API (local, dev 환경에서만 사용 가능)")
+@Tag(name = "\uD83E\uDDEA Init Monster API", description = "테스트용 몬스터 초기화 API (local, dev 환경에서만 사용 가능)")
 interface InitMonsterApi {
     @Operation(summary = "랜덤 1단계 몬스터 초기화", description = "인증된 유저에게 랜덤 1단계 몬스터를 소유시킵니다.")
     fun initRandomMonster(user: User): CustomResponse<InitMonsterResponse>

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/InitMonsterController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/InitMonsterController.kt
@@ -1,0 +1,39 @@
+package tamago.server.gateway.presentation.monster.v1.controller
+
+import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import tamago.server.core.monster.MonsterFacade
+import tamago.server.core.user.domain.aggregate.User
+import tamago.server.gateway.common.annotation.CurrentUser
+import tamago.server.gateway.common.response.CustomResponse
+import tamago.server.gateway.presentation.monster.v1.api.InitMonsterApi
+import tamago.server.gateway.presentation.monster.v1.response.InitMonsterResponse
+
+@Profile("local", "dev")
+@RestController
+class InitMonsterController(
+    private val monsterFacade: MonsterFacade,
+) : InitMonsterApi {
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/api/v1/monsters/init")
+    override fun initRandomMonster(
+        @CurrentUser user: User,
+    ): CustomResponse<InitMonsterResponse> {
+        val result = monsterFacade.initRandomMonster(user.id!!)
+
+        return CustomResponse.created(
+            InitMonsterResponse(
+                ownedMonsterId = result.ownedMonsterId,
+                monsterId = result.monsterId,
+                nickname = result.nickname,
+                status = result.status,
+            ),
+        )
+    }
+}

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/response/InitMonsterResponse.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/response/InitMonsterResponse.kt
@@ -1,0 +1,18 @@
+package tamago.server.gateway.presentation.monster.v1.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "몬스터 초기화 응답")
+data class InitMonsterResponse(
+    @field:Schema(description = "소유 몬스터 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    val ownedMonsterId: Long,
+
+    @field:Schema(description = "몬스터 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    val monsterId: Long,
+
+    @field:Schema(description = "몬스터 닉네임", example = "타마알", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    val nickname: String?,
+
+    @field:Schema(description = "소유 상태", example = "OWNED", requiredMode = Schema.RequiredMode.REQUIRED)
+    val status: String,
+)

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/api/RunningApi.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/api/RunningApi.kt
@@ -1,0 +1,14 @@
+package tamago.server.gateway.presentation.running.v1.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import tamago.server.core.user.domain.aggregate.User
+import tamago.server.gateway.common.response.CustomResponse
+import tamago.server.gateway.presentation.running.v1.request.RunningRequest
+import tamago.server.gateway.presentation.running.v1.response.RunningFinishResponse
+
+@Tag(name = "Running API", description = "러닝 데이터 API")
+interface RunningApi {
+    @Operation(summary = "러닝 데이터 저장", description = "사용자의 러닝 데이터를 저장하고, 계산된 러닝 데이터와 몬스터 경험치를 반환합니다.")
+    fun saveRunningData(user: User, request: RunningRequest): CustomResponse<RunningFinishResponse>
+}

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/controller/RunningController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/controller/RunningController.kt
@@ -43,6 +43,7 @@ class RunningController(
                         stage = stage.stage,
                         monsterId = stage.monsterId,
                         evolutionXp = stage.evolutionXp,
+                        current = stage.current,
                     )
                 },
             ),

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/controller/RunningController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/controller/RunningController.kt
@@ -1,0 +1,51 @@
+package tamago.server.gateway.presentation.running.v1.controller
+
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import tamago.server.core.running.RunningFacade
+import tamago.server.core.user.domain.aggregate.User
+import tamago.server.gateway.common.annotation.CurrentUser
+import tamago.server.gateway.common.response.CustomResponse
+import tamago.server.gateway.presentation.running.v1.api.RunningApi
+import tamago.server.gateway.presentation.running.v1.request.RunningRequest
+import tamago.server.gateway.presentation.running.v1.request.toCommand
+import tamago.server.gateway.presentation.running.v1.response.RunningFinishResponse
+
+@RestController
+class RunningController(
+    private val runningFacade: RunningFacade,
+) : RunningApi {
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/api/v1/running")
+    override fun saveRunningData(
+        @CurrentUser user: User,
+        @RequestBody @Valid request: RunningRequest,
+    ): CustomResponse<RunningFinishResponse> {
+        val result = runningFacade.saveRunningData(request.toCommand(user.id!!, user.weight))
+
+        return CustomResponse.created(
+            RunningFinishResponse(
+                pace = result.pace,
+                cadence = result.cadence,
+                elapsedTime = result.elapsedTime,
+                totalCalories = result.totalCalories,
+                originXp = result.originXp,
+                earnedXp = result.earnedXp,
+                evolutionStages = result.evolutionStages.map { stage ->
+                    RunningFinishResponse.EvolutionStageResponse(
+                        stage = stage.stage,
+                        monsterId = stage.monsterId,
+                        evolutionXp = stage.evolutionXp,
+                    )
+                },
+            ),
+        )
+    }
+}

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/request/RunningRequest.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/request/RunningRequest.kt
@@ -1,0 +1,39 @@
+package tamago.server.gateway.presentation.running.v1.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import tamago.server.core.common.vo.UserId
+import tamago.server.core.monster.domain.vo.OwnedMonsterId
+import tamago.server.core.running.domain.port.inbound.command.SaveRunningCommandDto
+import java.time.LocalDateTime
+
+@Schema(description = "러닝 데이터 저장 바디")
+data class RunningRequest(
+    @field:Schema(description = "러닝 거리 (km)", example = "5.23", requiredMode = Schema.RequiredMode.REQUIRED)
+    val distance: Double,
+
+    @field:Schema(description = "누적 고도 상승 (m)", example = "120.5", requiredMode = Schema.RequiredMode.REQUIRED)
+    val elevationGain: Double,
+
+    @field:Schema(description = "평균 심박수 (bpm)", example = "145", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    val heartbeat: Int,
+
+    @field:Schema(description = "러닝 시작 시간", example = "2025-01-15T08:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    val startedAt: LocalDateTime,
+
+    @field:Schema(description = "러닝 종료 시간", example = "2025-01-15T09:15:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    val finishedAt: LocalDateTime,
+
+    @field:Schema(description = "소유한 몬스터 ID", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
+    val ownedMonsterId: OwnedMonsterId,
+)
+
+fun RunningRequest.toCommand(userId: UserId, weight: Double) = SaveRunningCommandDto(
+    userId = userId,
+    weight = weight,
+    distance = distance,
+    elevationGain = elevationGain,
+    heartbeat = heartbeat,
+    startedAt = startedAt,
+    finishedAt = finishedAt,
+    ownedMonsterId = ownedMonsterId,
+)

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/request/RunningRequest.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/request/RunningRequest.kt
@@ -15,7 +15,7 @@ data class RunningRequest(
     val elevationGain: Double,
 
     @field:Schema(description = "평균 심박수 (bpm)", example = "145", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    val heartbeat: Int,
+    val heartbeat: Int?,
 
     @field:Schema(description = "러닝 시작 시간", example = "2025-01-15T08:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
     val startedAt: LocalDateTime,

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/request/RunningRequest.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/request/RunningRequest.kt
@@ -24,7 +24,7 @@ data class RunningRequest(
     val finishedAt: LocalDateTime,
 
     @field:Schema(description = "소유한 몬스터 ID", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
-    val ownedMonsterId: OwnedMonsterId,
+    val ownedMonsterId: Long,
 )
 
 fun RunningRequest.toCommand(userId: UserId, weight: Double) = SaveRunningCommandDto(
@@ -35,5 +35,5 @@ fun RunningRequest.toCommand(userId: UserId, weight: Double) = SaveRunningComman
     heartbeat = heartbeat,
     startedAt = startedAt,
     finishedAt = finishedAt,
-    ownedMonsterId = ownedMonsterId,
+    ownedMonsterId = OwnedMonsterId(ownedMonsterId),
 )

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/response/RunningFinishResponse.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/response/RunningFinishResponse.kt
@@ -1,0 +1,39 @@
+package tamago.server.gateway.presentation.running.v1.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "러닝 종료 응답")
+data class RunningFinishResponse(
+    @field:Schema(description = "페이스 (초/km)", example = "360", requiredMode = Schema.RequiredMode.REQUIRED)
+    val pace: Int,
+
+    @field:Schema(description = "케이던스 (spm)", example = "170", requiredMode = Schema.RequiredMode.REQUIRED)
+    val cadence: Int,
+
+    @field:Schema(description = "경과 시간 (초)", example = "2700", requiredMode = Schema.RequiredMode.REQUIRED)
+    val elapsedTime: Int,
+
+    @field:Schema(description = "총 소모 칼로리 (kcal)", example = "350", requiredMode = Schema.RequiredMode.REQUIRED)
+    val totalCalories: Int,
+
+    @field:Schema(description = "원래 경험치", example = "500", requiredMode = Schema.RequiredMode.REQUIRED)
+    val originXp : Int,
+
+    @field:Schema(description = "현재 경험치", example = "700", requiredMode = Schema.RequiredMode.REQUIRED)
+    val earnedXp: Int,
+
+    @field:Schema(description = "진화 단계별 몬스터 정보 (최대 4단계)", requiredMode = Schema.RequiredMode.REQUIRED)
+    val evolutionStages: List<EvolutionStageResponse>,
+) {
+    @Schema(description = "진화 단계 정보 응답")
+    data class EvolutionStageResponse(
+        @field:Schema(description = "진화 단계 (1~4)", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        val stage: Int,
+
+        @field:Schema(description = "해당 단계 몬스터 ID", example = "2", requiredMode = Schema.RequiredMode.REQUIRED)
+        val monsterId: Long,
+
+        @field:Schema(description = "다음 단계로 진화에 필요한 경험치", example = "200", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        val evolutionXp: Int?,
+    )
+}

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/response/RunningFinishResponse.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/response/RunningFinishResponse.kt
@@ -35,5 +35,8 @@ data class RunningFinishResponse(
 
         @field:Schema(description = "다음 단계로 진화에 필요한 경험치", example = "200", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         val evolutionXp: Int?,
+
+        @field:Schema(description = "현재 단계 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        val current: Boolean,
     )
 }

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/api/UserApi.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/api/UserApi.kt
@@ -5,11 +5,15 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import tamago.server.core.user.domain.aggregate.User
 import tamago.server.gateway.presentation.user.v1.request.GoalKiloRequest
 import tamago.server.gateway.presentation.user.v1.request.NicknameRequest
+import tamago.server.gateway.presentation.user.v1.response.MeResponse
 import tamago.server.gateway.presentation.user.v1.response.RunningDataResponse
 import tamago.server.gateway.common.response.CustomResponse
 
 @Tag(name = "User API", description = "유저 관련 API")
 interface UserApi {
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 유저의 정보를 반환합니다.")
+    fun me(user: User): CustomResponse<MeResponse>
+
     @Operation(summary = "애칭 설정하기", description = "타마고 애칭을 설정합니다.")
     fun giveNickname(user: User, request: NicknameRequest): CustomResponse<Void>
 

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/controller/UserController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/controller/UserController.kt
@@ -11,6 +11,7 @@ import tamago.server.core.user.domain.aggregate.User
 import tamago.server.gateway.presentation.user.v1.api.UserApi
 import tamago.server.gateway.presentation.user.v1.request.GoalKiloRequest
 import tamago.server.gateway.presentation.user.v1.request.NicknameRequest
+import tamago.server.gateway.presentation.user.v1.response.MeResponse
 import tamago.server.gateway.presentation.user.v1.response.RunningDataResponse
 import tamago.server.gateway.common.response.CustomResponse
 import tamago.server.gateway.common.annotation.CurrentUser
@@ -21,6 +22,12 @@ import java.time.temporal.ChronoUnit
 class UserController(
     private val userCommandUseCase: UserCommandUseCase,
 ) : UserApi {
+
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/api/v1/users/me")
+    override fun me(
+        @CurrentUser user: User
+    ): CustomResponse<MeResponse> = CustomResponse.ok(MeResponse.from(user))
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @PatchMapping("/api/v1/users/nickname")

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/response/MeResponse.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/response/MeResponse.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 
 data class MeResponse(
     @field:Schema(description = "유저 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-    val id: Long?,
+    val id: Long,
 
     @field:Schema(description = "닉네임", example = "타마고")
     val nickname: String?,
@@ -53,7 +53,7 @@ data class MeResponse(
 
     companion object {
         fun from(user: User): MeResponse = MeResponse(
-            id = user.id?.value,
+            id = user.id!!.value,
             nickname = user.nickname,
             role = user.role,
             weight = user.weight,

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/response/MeResponse.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/user/v1/response/MeResponse.kt
@@ -1,0 +1,75 @@
+package tamago.server.gateway.presentation.user.v1.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import tamago.server.core.user.domain.aggregate.User
+import tamago.server.core.user.domain.aggregate.UserAuth
+import tamago.server.core.user.domain.enum.AuthProvider
+import tamago.server.core.user.domain.enum.UserRole
+import java.time.LocalDateTime
+
+data class MeResponse(
+    @field:Schema(description = "유저 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    val id: Long?,
+
+    @field:Schema(description = "닉네임", example = "타마고")
+    val nickname: String?,
+
+    @field:Schema(description = "유저 역할", example = "USER", requiredMode = Schema.RequiredMode.REQUIRED)
+    val role: UserRole,
+
+    @field:Schema(description = "몸무게 (kg)", example = "70.0", requiredMode = Schema.RequiredMode.REQUIRED)
+    val weight: Double,
+
+    @field:Schema(description = "러닝 데이터", requiredMode = Schema.RequiredMode.REQUIRED)
+    val runningData: RunningDataDto,
+
+    @field:Schema(description = "인증 정보 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+    val auths: List<AuthDto>,
+
+    @field:Schema(description = "마지막 로그인 일시")
+    val lastLoginAt: LocalDateTime?,
+
+    @field:Schema(description = "가입 일시")
+    val createdAt: LocalDateTime?,
+
+    @field:Schema(description = "수정 일시")
+    val updatedAt: LocalDateTime?,
+) {
+    data class RunningDataDto(
+        @field:Schema(description = "하루 러닝 목표 (km)", example = "5")
+        val goalKilo: Int?,
+
+        @field:Schema(description = "누적 러닝 거리 (km)", example = "42.5")
+        val totalKilo: Double?,
+    )
+
+    data class AuthDto(
+        @field:Schema(description = "이메일", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+        val email: String,
+
+        @field:Schema(description = "인증 제공자", example = "KAKAO", requiredMode = Schema.RequiredMode.REQUIRED)
+        val provider: AuthProvider,
+    )
+
+    companion object {
+        fun from(user: User): MeResponse = MeResponse(
+            id = user.id?.value,
+            nickname = user.nickname,
+            role = user.role,
+            weight = user.weight,
+            runningData = RunningDataDto(
+                goalKilo = user.runningData.goalKilo,
+                totalKilo = user.runningData.totalKilo,
+            ),
+            auths = user.auths.map { auth ->
+                AuthDto(
+                    email = auth.email,
+                    provider = auth.provider,
+                )
+            },
+            lastLoginAt = user.lastLoginAt,
+            createdAt = user.createdAt,
+            updatedAt = user.updatedAt,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

>- #28 

러닝 종료 시 러닝 데이터 저장하고 타마고 몬스터 진화 경험치를 반환하는 API

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- dev 환경에서 필요한 seed 데이터 flyway 기반으로 주입
- 러닝 데이터 저장 API 설계
- Swagger UI API 목록 정렬 조건 추가
- 테스트 유저에 특정 타마고 몬스터 할당하는 테스트용 API 추가
- 현재 로그인 한 유저 조회 API

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 몬스터 초기화 API 추가 — 랜덤 시작 몬스터 획득 및 초기 정보(소유 ID, 몬스터 ID, 닉네임, 상태) 반환.
  * 달리기 데이터 저장 API 추가 — 페이스/보폭/칼로리 계산과 진화 단계 정보를 포함한 결과 반환.
  * 현재 사용자 정보 조회(me) 엔드포인트 추가.

* **Refactor**
  * 요청/응답 DTO 및 API 모델명 정비(타입/필드명 변경).
  * 몬스터·소유몬스터·진화정책 필드명·구조 개선 및 진화 체인 처리 보강.
  * 러닝 도메인/엔티티 측 주요 필드(거리/페이스→distance·cadence·calories 등) 재정의.

* **Chores**
  * DB 마이그레이션·시드 업데이트 및 Flyway 설정 분리.
  * Swagger/문서 정렬 및 일부 응답 헬퍼·요청명칭 정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->