### PR TITLE
feat: 러닝 완료 후 몬스터 알 해금 이벤트 구현하고 관련 API 설계

### DIFF
--- a/tamago-core/src/main/kotlin/tamago/server/core/common/jdsl/JdslExtensions.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/common/jdsl/JdslExtensions.kt
@@ -24,5 +24,6 @@ inline fun <reified T : Any> EntityManager.findOne(
     val rendered = JpqlRenderer().render(query, context)
     return createQuery(rendered.query, T::class.java)
         .apply { rendered.params.forEach { (key, value) -> setParameter(key, value) } }
-        .singleResult
+        .resultList
+        .firstOrNull()
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/common/jdsl/JdslExtensions.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/common/jdsl/JdslExtensions.kt
@@ -15,3 +15,14 @@ inline fun <reified T : Any> EntityManager.findAll(
         .apply { rendered.params.forEach { (key, value) -> setParameter(key, value) } }
         .resultList
 }
+
+@Suppress("SqlSourceToSinkFlow")
+inline fun <reified T : Any> EntityManager.findOne(
+    query: JpqlQuery<*>,
+    context: JpqlRenderContext,
+): T? {
+    val rendered = JpqlRenderer().render(query, context)
+    return createQuery(rendered.query, T::class.java)
+        .apply { rendered.params.forEach { (key, value) -> setParameter(key, value) } }
+        .singleResult
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterCommandUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterCommandUseCase.kt
@@ -1,14 +1,7 @@
 package tamago.server.core.monster
 
-import tamago.server.core.common.vo.UserId
-import tamago.server.core.monster.domain.aggregate.MonsterAsset
 import tamago.server.core.monster.domain.aggregate.OwnedMonster
-import tamago.server.core.monster.domain.enum.AssetType
-import tamago.server.core.monster.domain.vo.MonsterId
 
 interface MonsterCommandUseCase {
-    fun initMonster(userId: UserId, monsterId: MonsterId): OwnedMonster
-    fun createMonsterAsset(monsterId: MonsterId, assetType: AssetType, assetKey: String): MonsterAsset
     fun addEarnedXp(ownedMonster: OwnedMonster, xp: Int): OwnedMonster
-    fun ownMonster(ownedMonster: OwnedMonster): OwnedMonster
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterCommandUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterCommandUseCase.kt
@@ -10,4 +10,5 @@ interface MonsterCommandUseCase {
     fun initMonster(userId: UserId, monsterId: MonsterId): OwnedMonster
     fun createMonsterAsset(monsterId: MonsterId, assetType: AssetType, assetKey: String): MonsterAsset
     fun addEarnedXp(ownedMonster: OwnedMonster, xp: Int): OwnedMonster
+    fun ownMonster(ownedMonster: OwnedMonster): OwnedMonster
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterCommandUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterCommandUseCase.kt
@@ -9,4 +9,5 @@ import tamago.server.core.monster.domain.vo.MonsterId
 interface MonsterCommandUseCase {
     fun initMonster(userId: UserId, monsterId: MonsterId): OwnedMonster
     fun createMonsterAsset(monsterId: MonsterId, assetType: AssetType, assetKey: String): MonsterAsset
+    fun addEarnedXp(ownedMonster: OwnedMonster, xp: Int): OwnedMonster
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
@@ -11,6 +11,7 @@ import tamago.server.core.monster.domain.port.inbound.query.CreateMonsterAssetQu
 import tamago.server.core.monster.domain.port.inbound.query.InitMonsterQueryDto
 import tamago.server.core.monster.domain.port.inbound.query.MonsterDexQueryDto
 import tamago.server.core.monster.domain.vo.MonsterId
+import tamago.server.core.monster.domain.vo.OwnedMonsterId
 
 @Component
 class MonsterFacade(
@@ -70,5 +71,11 @@ class MonsterFacade(
             previewUrl = generatedUrl.previewUrl,
             assetKey = assetKey,
         )
+    }
+
+    @Transactional
+    fun ownMonster(ownedMonsterId: OwnedMonsterId) {
+        val ownedMonster = monsterQueryUseCase.getOwnedMonster(ownedMonsterId)
+        monsterCommandUseCase.ownMonster(ownedMonster)
     }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
@@ -10,6 +10,7 @@ import tamago.server.core.monster.domain.enum.AssetType
 import tamago.server.core.monster.domain.port.inbound.query.CreateMonsterAssetQueryDto
 import tamago.server.core.monster.domain.port.inbound.query.InitMonsterQueryDto
 import tamago.server.core.monster.domain.port.inbound.query.MonsterDexQueryDto
+import tamago.server.core.monster.application.exception.MonsterAccessDeniedException
 import tamago.server.core.monster.application.service.MonsterCommandService
 import tamago.server.core.monster.application.service.MonsterQueryService
 import tamago.server.core.monster.domain.vo.MonsterId
@@ -76,8 +77,11 @@ class MonsterFacade(
     }
 
     @Transactional
-    fun ownMonster(ownedMonsterId: OwnedMonsterId) {
+    fun ownMonster(ownedMonsterId: OwnedMonsterId, ownerId: UserId) {
         val ownedMonster = monsterQueryService.getOwnedMonster(ownedMonsterId)
+        if (ownedMonster.userId != ownerId) {
+            throw MonsterAccessDeniedException()
+        }
         monsterCommandService.ownMonster(ownedMonster)
     }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
@@ -10,29 +10,31 @@ import tamago.server.core.monster.domain.enum.AssetType
 import tamago.server.core.monster.domain.port.inbound.query.CreateMonsterAssetQueryDto
 import tamago.server.core.monster.domain.port.inbound.query.InitMonsterQueryDto
 import tamago.server.core.monster.domain.port.inbound.query.MonsterDexQueryDto
+import tamago.server.core.monster.application.service.MonsterCommandService
+import tamago.server.core.monster.application.service.MonsterQueryService
 import tamago.server.core.monster.domain.vo.MonsterId
 import tamago.server.core.monster.domain.vo.OwnedMonsterId
 
 @Component
 class MonsterFacade(
-    private val monsterCommandUseCase: MonsterCommandUseCase,
-    private val monsterQueryUseCase: MonsterQueryUseCase,
+    private val monsterCommandService: MonsterCommandService,
+    private val monsterQueryService: MonsterQueryService,
     private val imageProcessor: ImageProcessor,
     private val imageFileConstructor: ImageFileConstructor,
 ) {
     @Transactional(readOnly = true)
     fun getMonsterDex(userId: UserId): List<MonsterDexQueryDto> {
         // 1단계 몬스터와 해금 조건 함께 조회
-        val monsters = monsterQueryUseCase.getAllFirstStageWithUnlockPolicies()
+        val monsters = monsterQueryService.getAllFirstStageWithUnlockPolicies()
         // 내가 소유한 몬스터 조회
-        val ownedMonsterMap = monsterQueryUseCase.getOwnedMonstersByUserId(userId)
+        val ownedMonsterMap = monsterQueryService.getOwnedMonstersByUserId(userId)
             .associateBy { it.monsterId }
 
         return monsters.map { monster ->
             // 내가 소유한 몬스터인지 확인
             val ownedMonster = ownedMonsterMap[monster.id]
             // 몬스터의 PNG 이미지만 조회
-            val imageUrl = ownedMonster?.let { monsterQueryUseCase.getMonsterPngUrl(monster.id!!) }
+            val imageUrl = ownedMonster?.let { monsterQueryService.getMonsterPngUrl(monster.id!!) }
 
             MonsterDexQueryDto.of(monster, ownedMonster, imageUrl)
         }
@@ -40,8 +42,8 @@ class MonsterFacade(
 
     @Transactional
     fun initRandomMonster(userId: UserId): InitMonsterQueryDto {
-        val monster = monsterQueryUseCase.getRandomFirstStageMonster()
-        val ownedMonster = monsterCommandUseCase.initMonster(userId, monster.id!!)
+        val monster = monsterQueryService.getRandomFirstStageMonster()
+        val ownedMonster = monsterCommandService.initMonster(userId, monster.id!!)
 
         return InitMonsterQueryDto(
             ownedMonsterId = ownedMonster.id!!.value,
@@ -53,7 +55,7 @@ class MonsterFacade(
 
     @Transactional
     fun createMonsterAssetUploadUrl(monsterId: MonsterId, assetType: AssetType): CreateMonsterAssetQueryDto {
-        monsterQueryUseCase.checkMonsterAssetNotExists(monsterId, assetType)
+        monsterQueryService.checkMonsterAssetNotExists(monsterId, assetType)
 
         val assetKey = imageFileConstructor.imageFilePath(ImagePrefix.MONSTER.value, monsterId.value)
 
@@ -64,7 +66,7 @@ class MonsterFacade(
             extension = assetType.extension,
         )
 
-        monsterCommandUseCase.createMonsterAsset(monsterId, assetType, assetKey)
+        monsterCommandService.createMonsterAsset(monsterId, assetType, assetKey)
 
         return CreateMonsterAssetQueryDto(
             uploadUrl = generatedUrl.uploadUrl,
@@ -75,7 +77,7 @@ class MonsterFacade(
 
     @Transactional
     fun ownMonster(ownedMonsterId: OwnedMonsterId) {
-        val ownedMonster = monsterQueryUseCase.getOwnedMonster(ownedMonsterId)
-        monsterCommandUseCase.ownMonster(ownedMonster)
+        val ownedMonster = monsterQueryService.getOwnedMonster(ownedMonsterId)
+        monsterCommandService.ownMonster(ownedMonster)
     }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterQueryUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterQueryUseCase.kt
@@ -19,4 +19,5 @@ interface MonsterQueryUseCase {
     fun getRandomFirstStageMonster(): Monster
     fun checkMonsterAssetNotExists(monsterId: MonsterId, assetType: AssetType)
     fun getMonsterPngUrl(monsterId: MonsterId): String?
+    fun getUnlockedMonsters(userId: UserId): List<OwnedMonster>
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterQueryUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterQueryUseCase.kt
@@ -2,22 +2,13 @@ package tamago.server.core.monster
 
 import tamago.server.core.common.vo.UserId
 import tamago.server.core.monster.domain.aggregate.Monster
-import tamago.server.core.monster.domain.aggregate.MonsterAsset
 import tamago.server.core.monster.domain.aggregate.OwnedMonster
-import tamago.server.core.monster.domain.enum.AssetType
 import tamago.server.core.monster.domain.vo.MonsterId
 import tamago.server.core.monster.domain.vo.OwnedMonsterId
 
 interface MonsterQueryUseCase {
-    fun get(id: MonsterId): Monster
-    fun getAllWithUnlockPolicies(): List<Monster>
-    fun getAllFirstStageWithUnlockPolicies(): List<Monster>
     fun getOwnedMonster(id: OwnedMonsterId): OwnedMonster
-    fun getOwnedMonstersByUserId(userId: UserId): List<OwnedMonster>
-    fun getMonsterAssetsByMonsterIds(monsterIds: List<MonsterId>, assetType: AssetType): List<MonsterAsset>
     fun getEvolutionChain(monsterId: MonsterId): List<Monster>
-    fun getRandomFirstStageMonster(): Monster
-    fun checkMonsterAssetNotExists(monsterId: MonsterId, assetType: AssetType)
     fun getMonsterPngUrl(monsterId: MonsterId): String?
     fun getUnlockedMonsters(userId: UserId): List<OwnedMonster>
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/event/MonsterEventListener.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/event/MonsterEventListener.kt
@@ -1,0 +1,38 @@
+package tamago.server.core.monster.application.event
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionalEventListener
+import tamago.server.core.monster.application.service.MonsterCommandService
+import tamago.server.core.monster.application.service.MonsterQueryService
+import tamago.server.core.running.domain.event.RunningCompletedEvent
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class MonsterEventListener(
+    private val monsterQueryService: MonsterQueryService,
+    private val monsterCommandService: MonsterCommandService,
+) {
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun onRunningCompleted(event: RunningCompletedEvent) {
+        try {
+            val allFirstStageMonsters = monsterQueryService.getAllFirstStageWithUnlockPolicies()
+
+            // 이미 보유한 몬스터 ID 목록 조회
+            val ownedMonsters = monsterQueryService.getOwnedMonstersByUserId(event.userId)
+            val ownedMonsterIds = ownedMonsters.map { it.monsterId }.toSet()
+
+            allFirstStageMonsters
+                .filter { monster -> monster.id !in ownedMonsterIds } // 이미 보유한 몬스터는 제외
+                .filter { monster -> monster.unlockPolicies.any { it.isSatisfiedBy(event.totalDistance) } }
+                .forEach { monster -> monsterCommandService.unlockMonster(monster.id!!, event.userId) }
+        } catch (e: Exception) {
+            // TODO: Sentry 연동
+            logger.error(e) { "러닝 완료 후 몬스터 해금 처리 오류 - userId: ${event.userId}" }
+        }
+    }
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterAccessDeniedException.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterAccessDeniedException.kt
@@ -1,0 +1,7 @@
+package tamago.server.core.monster.application.exception
+
+import tamago.server.core.common.exception.BusinessException
+
+class MonsterAccessDeniedException : BusinessException(
+    MonsterExceptionCode.MONSTER_ACCESS_DENIED,
+)

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterAlreadyOwnedException.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterAlreadyOwnedException.kt
@@ -1,0 +1,7 @@
+package tamago.server.core.monster.application.exception
+
+import tamago.server.core.common.exception.BusinessException
+
+class MonsterAlreadyOwnedException : BusinessException(
+    MonsterExceptionCode.MONSTER_ALREADY_OWNED,
+)

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterExceptionCode.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterExceptionCode.kt
@@ -11,6 +11,7 @@ enum class MonsterExceptionCode(
     MONSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MONSTER_4040", "몬스터를 찾을 수 없습니다."),
     OWNED_MONSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MONSTER_4041", "소유한 몬스터를 찾을 수 없습니다."),
     MONSTER_ASSET_ALREADY_EXISTS(HttpStatus.CONFLICT, "MONSTER_4090", "해당 몬스터의 에셋이 이미 존재합니다."),
+    MONSTER_ALREADY_OWNED(HttpStatus.CONFLICT, "MONSTER_4091", "이미 소유한 몬스터입니다."),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterExceptionCode.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterExceptionCode.kt
@@ -11,6 +11,7 @@ enum class MonsterExceptionCode(
     MONSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MONSTER_4040", "몬스터를 찾을 수 없습니다."),
     OWNED_MONSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MONSTER_4041", "소유한 몬스터를 찾을 수 없습니다."),
     MONSTER_ASSET_ALREADY_EXISTS(HttpStatus.CONFLICT, "MONSTER_4090", "해당 몬스터의 에셋이 이미 존재합니다."),
+    MONSTER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "MONSTER_4030", "해당 몬스터에 접근 권한이 없습니다."),
     MONSTER_ALREADY_OWNED(HttpStatus.CONFLICT, "MONSTER_4091", "이미 소유한 몬스터입니다."),
     ;
 

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
@@ -42,4 +42,14 @@ class MonsterCommandService(
         val updated = ownedMonster.addXp(xp)
         return ownedMonsterPersistencePort.save(updated)
     }
+
+    fun unlockMonster(monsterId: MonsterId, userId: UserId): OwnedMonster {
+        val ownedMonster = OwnedMonster.create(
+            monsterId = monsterId,
+            userId = userId,
+            havingXp = 0,
+            status = OwnedMonsterStatus.UNLOCKED,
+        )
+        return ownedMonsterPersistencePort.save(ownedMonster)
+    }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
@@ -18,7 +18,7 @@ class MonsterCommandService(
     private val monsterAssetPersistencePort: MonsterAssetPersistencePort,
 ) : MonsterCommandUseCase {
 
-    override fun initMonster(userId: UserId, monsterId: MonsterId): OwnedMonster {
+    fun initMonster(userId: UserId, monsterId: MonsterId): OwnedMonster {
         val ownedMonster = OwnedMonster.create(
             monsterId = monsterId,
             userId = userId,
@@ -29,7 +29,7 @@ class MonsterCommandService(
         return ownedMonsterPersistencePort.save(ownedMonster)
     }
 
-    override fun createMonsterAsset(monsterId: MonsterId, assetType: AssetType, assetKey: String): MonsterAsset {
+    fun createMonsterAsset(monsterId: MonsterId, assetType: AssetType, assetKey: String): MonsterAsset {
         val monsterAsset = MonsterAsset.create(
             monsterId = monsterId,
             assetKey = assetKey,
@@ -44,7 +44,7 @@ class MonsterCommandService(
         return ownedMonsterPersistencePort.save(ownedMonster)
     }
 
-    override fun ownMonster(ownedMonster: OwnedMonster): OwnedMonster {
+    fun ownMonster(ownedMonster: OwnedMonster): OwnedMonster {
         if (ownedMonster.status != OwnedMonsterStatus.UNLOCKED) {
             throw MonsterAlreadyOwnedException()
         }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
@@ -6,6 +6,7 @@ import tamago.server.core.monster.MonsterCommandUseCase
 import tamago.server.core.monster.domain.aggregate.MonsterAsset
 import tamago.server.core.monster.domain.aggregate.OwnedMonster
 import tamago.server.core.monster.domain.enum.AssetType
+import tamago.server.core.monster.application.exception.MonsterAlreadyOwnedException
 import tamago.server.core.monster.domain.enum.OwnedMonsterStatus
 import tamago.server.core.monster.domain.port.outbound.MonsterAssetPersistencePort
 import tamago.server.core.monster.domain.port.outbound.OwnedMonsterPersistencePort
@@ -41,6 +42,14 @@ class MonsterCommandService(
     override fun addEarnedXp(ownedMonster: OwnedMonster, xp: Int): OwnedMonster {
         val updated = ownedMonster.addXp(xp)
         return ownedMonsterPersistencePort.save(updated)
+    }
+
+    override fun ownMonster(ownedMonster: OwnedMonster): OwnedMonster {
+        if (ownedMonster.status != OwnedMonsterStatus.UNLOCKED) {
+            throw MonsterAlreadyOwnedException()
+        }
+        val owned = ownedMonster.own()
+        return ownedMonsterPersistencePort.save(owned)
     }
 
     fun unlockMonster(monsterId: MonsterId, userId: UserId): OwnedMonster {

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
@@ -37,4 +37,9 @@ class MonsterCommandService(
 
         return monsterAssetPersistencePort.save(monsterAsset)
     }
+
+    override fun addEarnedXp(ownedMonster: OwnedMonster, xp: Int): OwnedMonster {
+        val updated = ownedMonster.addXp(xp)
+        return ownedMonsterPersistencePort.save(updated)
+    }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
@@ -40,16 +40,16 @@ class MonsterCommandService(
     }
 
     override fun addEarnedXp(ownedMonster: OwnedMonster, xp: Int): OwnedMonster {
-        val updated = ownedMonster.addXp(xp)
-        return ownedMonsterPersistencePort.save(updated)
+        ownedMonster.addXp(xp)
+        return ownedMonsterPersistencePort.save(ownedMonster)
     }
 
     override fun ownMonster(ownedMonster: OwnedMonster): OwnedMonster {
         if (ownedMonster.status != OwnedMonsterStatus.UNLOCKED) {
             throw MonsterAlreadyOwnedException()
         }
-        val owned = ownedMonster.own()
-        return ownedMonsterPersistencePort.save(owned)
+        ownedMonster.own()
+        return ownedMonsterPersistencePort.save(ownedMonster)
     }
 
     fun unlockMonster(monsterId: MonsterId, userId: UserId): OwnedMonster {

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
@@ -12,6 +12,7 @@ import tamago.server.core.monster.domain.aggregate.Monster
 import tamago.server.core.monster.domain.aggregate.MonsterAsset
 import tamago.server.core.monster.domain.aggregate.OwnedMonster
 import tamago.server.core.monster.domain.enum.AssetType
+import tamago.server.core.monster.domain.enum.OwnedMonsterStatus
 import tamago.server.core.monster.domain.port.outbound.MonsterAssetPersistencePort
 import tamago.server.core.monster.domain.port.outbound.MonsterPersistencePort
 import tamago.server.core.monster.domain.port.outbound.OwnedMonsterPersistencePort
@@ -82,6 +83,9 @@ class MonsterQueryService(
             throw MonsterAssetAlreadyExistsException()
         }
     }
+
+    override fun getUnlockedMonsters(userId: UserId): List<OwnedMonster> =
+        ownedMonsterPersistencePort.findAllByUserIdAndStatus(userId, OwnedMonsterStatus.UNLOCKED)
 
     override fun getMonsterPngUrl(monsterId: MonsterId): String? =
         imageProcessor.getImageUrl(

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
@@ -27,24 +27,24 @@ class MonsterQueryService(
     private val imageProcessor: ImageProcessor,
 ) : MonsterQueryUseCase {
 
-    override fun get(id: MonsterId): Monster =
+    fun get(id: MonsterId): Monster =
         monsterPersistencePort.findById(id)
             ?: throw MonsterNotFoundException()
 
-    override fun getAllWithUnlockPolicies(): List<Monster> =
+    fun getAllWithUnlockPolicies(): List<Monster> =
         monsterPersistencePort.findAllWithUnlockPolicies()
 
-    override fun getAllFirstStageWithUnlockPolicies(): List<Monster> =
+    fun getAllFirstStageWithUnlockPolicies(): List<Monster> =
         monsterPersistencePort.findAllFirstStageWithUnlockPolicies()
 
     override fun getOwnedMonster(id: OwnedMonsterId): OwnedMonster =
         ownedMonsterPersistencePort.findById(id)
             ?: throw OwnedMonsterNotFoundException()
 
-    override fun getOwnedMonstersByUserId(userId: UserId): List<OwnedMonster> =
+    fun getOwnedMonstersByUserId(userId: UserId): List<OwnedMonster> =
         ownedMonsterPersistencePort.findAllByUserId(userId)
 
-    override fun getMonsterAssetsByMonsterIds(monsterIds: List<MonsterId>, assetType: AssetType): List<MonsterAsset> =
+    fun getMonsterAssetsByMonsterIds(monsterIds: List<MonsterId>, assetType: AssetType): List<MonsterAsset> =
         monsterAssetPersistencePort.findAllByMonsterIdsAndAssetType(monsterIds, assetType)
 
     override fun getEvolutionChain(monsterId: MonsterId): List<Monster> {
@@ -72,13 +72,13 @@ class MonsterQueryService(
         return previousChain.reversed() + current + nextChain
     }
 
-    override fun getRandomFirstStageMonster(): Monster {
+    fun getRandomFirstStageMonster(): Monster {
         val firstStageMonsters = monsterPersistencePort.findAllByPreviousMonsterIdIsNull()
         if (firstStageMonsters.isEmpty()) throw MonsterNotFoundException()
         return firstStageMonsters.random()
     }
 
-    override fun checkMonsterAssetNotExists(monsterId: MonsterId, assetType: AssetType) {
+    fun checkMonsterAssetNotExists(monsterId: MonsterId, assetType: AssetType) {
         if (monsterAssetPersistencePort.existsByMonsterIdAndAssetType(monsterId, assetType)) {
             throw MonsterAssetAlreadyExistsException()
         }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
@@ -49,6 +49,7 @@ class MonsterQueryService(
     override fun getEvolutionChain(monsterId: MonsterId): List<Monster> {
         val current = monsterPersistencePort.findById(monsterId) ?: throw MonsterNotFoundException()
 
+        // 이전 진화 단계 몬스터들을 역순으로 수집
         val previousChain = mutableListOf<Monster>()
         var prevId: MonsterId? = current.previousMonsterId
         while (prevId != null) {
@@ -57,6 +58,7 @@ class MonsterQueryService(
             prevId = monster.previousMonsterId
         }
 
+        // 다음 진화 단계 몬스터들을 순서대로 수집
         val nextChain = mutableListOf<Monster>()
         var nextId: MonsterId? = current.nextMonsterId
         while (nextId != null) {
@@ -65,6 +67,7 @@ class MonsterQueryService(
             nextId = monster.nextMonsterId
         }
 
+        // 이전 단계 몬스터들 + 현재 몬스터 + 다음 단계 몬스터들 합치기
         return previousChain.reversed() + current + nextChain
     }
 

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/MonsterUnlockPolicy.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/MonsterUnlockPolicy.kt
@@ -15,19 +15,9 @@ class MonsterUnlockPolicy(
     val updatedAt: LocalDateTime? = null,
     val deletedAt: LocalDateTime? = null,
 ) {
-    companion object {
-        fun create(
-            monsterId: MonsterId,
-            ruleType: MonsterRuleType? = null,
-            ruleValue: Int? = null,
-            description: String? = null,
-        ): MonsterUnlockPolicy {
-            return MonsterUnlockPolicy(
-                monsterId = monsterId,
-                ruleType = ruleType,
-                ruleValue = ruleValue,
-                description = description,
-            )
+    fun isSatisfiedBy(totalDistance: Double): Boolean =
+        when (ruleType) {
+            MonsterRuleType.KILOMETER -> (ruleValue ?: Int.MAX_VALUE) <= totalDistance
+            null -> false
         }
-    }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/OwnedMonster.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/OwnedMonster.kt
@@ -24,7 +24,7 @@ class OwnedMonster(
 
     fun own() {
         status = OwnedMonsterStatus.OWNED
-        havingXp = 0
+        havingXp = havingXp ?: 0
     }
 
     fun addXp(xp: Int) {

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/OwnedMonster.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/OwnedMonster.kt
@@ -16,6 +16,19 @@ class OwnedMonster(
     val updatedAt: LocalDateTime? = null,
     val deletedAt: LocalDateTime? = null,
 ) {
+    fun own(): OwnedMonster {
+        return OwnedMonster(
+            id = id,
+            monsterId = monsterId,
+            userId = userId,
+            havingXp = havingXp,
+            status = OwnedMonsterStatus.OWNED,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            deletedAt = deletedAt,
+        )
+    }
+
     fun addXp(xp: Int): OwnedMonster {
         return OwnedMonster(
             id = id,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/OwnedMonster.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/OwnedMonster.kt
@@ -16,6 +16,19 @@ class OwnedMonster(
     val updatedAt: LocalDateTime? = null,
     val deletedAt: LocalDateTime? = null,
 ) {
+    fun addXp(xp: Int): OwnedMonster {
+        return OwnedMonster(
+            id = id,
+            monsterId = monsterId,
+            userId = userId,
+            havingXp = (havingXp ?: 0) + xp,
+            status = status,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            deletedAt = deletedAt,
+        )
+    }
+
     companion object {
         fun create(
             monsterId: MonsterId,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/OwnedMonster.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/aggregate/OwnedMonster.kt
@@ -10,36 +10,25 @@ class OwnedMonster(
     val id: OwnedMonsterId? = null,
     val monsterId: MonsterId,
     val userId: UserId,
-    val havingXp: Int? = null,
-    val status: OwnedMonsterStatus? = null,
+    havingXp: Int? = null,
+    status: OwnedMonsterStatus? = null,
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null,
     val deletedAt: LocalDateTime? = null,
 ) {
-    fun own(): OwnedMonster {
-        return OwnedMonster(
-            id = id,
-            monsterId = monsterId,
-            userId = userId,
-            havingXp = havingXp,
-            status = OwnedMonsterStatus.OWNED,
-            createdAt = createdAt,
-            updatedAt = updatedAt,
-            deletedAt = deletedAt,
-        )
+    var havingXp: Int? = havingXp
+        private set
+
+    var status: OwnedMonsterStatus? = status
+        private set
+
+    fun own() {
+        status = OwnedMonsterStatus.OWNED
+        havingXp = 0
     }
 
-    fun addXp(xp: Int): OwnedMonster {
-        return OwnedMonster(
-            id = id,
-            monsterId = monsterId,
-            userId = userId,
-            havingXp = (havingXp ?: 0) + xp,
-            status = status,
-            createdAt = createdAt,
-            updatedAt = updatedAt,
-            deletedAt = deletedAt,
-        )
+    fun addXp(xp: Int) {
+        havingXp = (havingXp ?: 0) + xp
     }
 
     companion object {

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/OwnedMonsterPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/OwnedMonsterPersistencePort.kt
@@ -2,10 +2,12 @@ package tamago.server.core.monster.domain.port.outbound
 
 import tamago.server.core.common.vo.UserId
 import tamago.server.core.monster.domain.aggregate.OwnedMonster
+import tamago.server.core.monster.domain.enum.OwnedMonsterStatus
 import tamago.server.core.monster.domain.vo.OwnedMonsterId
 
 interface OwnedMonsterPersistencePort {
     fun findById(id: OwnedMonsterId): OwnedMonster?
     fun findAllByUserId(userId: UserId): List<OwnedMonster>
+    fun findAllByUserIdAndStatus(userId: UserId, status: OwnedMonsterStatus): List<OwnedMonster>
     fun save(ownedMonster: OwnedMonster): OwnedMonster
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterJpaRepository.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterJpaRepository.kt
@@ -1,8 +1,10 @@
 package tamago.server.core.monster.infrastructure.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import tamago.server.core.monster.domain.enum.OwnedMonsterStatus
 import tamago.server.core.monster.infrastructure.entity.OwnedMonsterEntity
 
 interface OwnedMonsterJpaRepository : JpaRepository<OwnedMonsterEntity, Long> {
     fun findAllByUserId(userId: Long): List<OwnedMonsterEntity>
+    fun findAllByUserIdAndStatusAndDeletedAtIsNull(userId: Long, status: OwnedMonsterStatus): List<OwnedMonsterEntity>
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterJpaRepository.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterJpaRepository.kt
@@ -5,6 +5,6 @@ import tamago.server.core.monster.domain.enum.OwnedMonsterStatus
 import tamago.server.core.monster.infrastructure.entity.OwnedMonsterEntity
 
 interface OwnedMonsterJpaRepository : JpaRepository<OwnedMonsterEntity, Long> {
-    fun findAllByUserId(userId: Long): List<OwnedMonsterEntity>
+    fun findAllByUserIdAndDeletedAtIsNull(userId: Long): List<OwnedMonsterEntity>
     fun findAllByUserIdAndStatusAndDeletedAtIsNull(userId: Long, status: OwnedMonsterStatus): List<OwnedMonsterEntity>
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterPersistenceAdapter.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterPersistenceAdapter.kt
@@ -3,6 +3,7 @@ package tamago.server.core.monster.infrastructure.repository
 import org.springframework.stereotype.Repository
 import tamago.server.core.common.vo.UserId
 import tamago.server.core.monster.domain.aggregate.OwnedMonster
+import tamago.server.core.monster.domain.enum.OwnedMonsterStatus
 import tamago.server.core.monster.domain.port.outbound.OwnedMonsterPersistencePort
 import tamago.server.core.monster.domain.vo.OwnedMonsterId
 import tamago.server.core.monster.infrastructure.mapper.OwnedMonsterMapper
@@ -18,6 +19,10 @@ class OwnedMonsterPersistenceAdapter(
 
     override fun findAllByUserId(userId: UserId): List<OwnedMonster> =
         ownedMonsterJpaRepository.findAllByUserId(userId.value).mapNotNull { OwnedMonsterMapper.toDomain(it) }
+
+    override fun findAllByUserIdAndStatus(userId: UserId, status: OwnedMonsterStatus): List<OwnedMonster> =
+        ownedMonsterJpaRepository.findAllByUserIdAndStatusAndDeletedAtIsNull(userId.value, status)
+            .mapNotNull { OwnedMonsterMapper.toDomain(it) }
 
     override fun save(ownedMonster: OwnedMonster): OwnedMonster {
         val monsterEntity = monsterJpaRepository.findById(ownedMonster.monsterId.value).orElseThrow()

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterPersistenceAdapter.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/infrastructure/repository/OwnedMonsterPersistenceAdapter.kt
@@ -18,7 +18,8 @@ class OwnedMonsterPersistenceAdapter(
         OwnedMonsterMapper.toDomain(ownedMonsterJpaRepository.findById(id.value).orElse(null))
 
     override fun findAllByUserId(userId: UserId): List<OwnedMonster> =
-        ownedMonsterJpaRepository.findAllByUserId(userId.value).mapNotNull { OwnedMonsterMapper.toDomain(it) }
+        ownedMonsterJpaRepository.findAllByUserIdAndDeletedAtIsNull(userId.value)
+            .mapNotNull { OwnedMonsterMapper.toDomain(it) }
 
     override fun findAllByUserIdAndStatus(userId: UserId, status: OwnedMonsterStatus): List<OwnedMonster> =
         ownedMonsterJpaRepository.findAllByUserIdAndStatusAndDeletedAtIsNull(userId.value, status)

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningCommandUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningCommandUseCase.kt
@@ -1,8 +1,4 @@
 package tamago.server.core.running
 
-import tamago.server.core.running.domain.aggregate.Running
-import tamago.server.core.running.domain.port.inbound.command.SaveRunningCommandDto
-
 interface RunningCommandUseCase {
-    fun save(command: SaveRunningCommandDto): Running
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import tamago.server.core.running.domain.event.RunningCompletedEvent
 import tamago.server.core.common.vo.UserId
+import tamago.server.core.monster.MonsterCommandUseCase
 import tamago.server.core.monster.MonsterQueryUseCase
 import tamago.server.core.running.domain.port.inbound.command.SaveRunningCommandDto
 import tamago.server.core.running.domain.port.inbound.query.MonthlyRunningQueryDto
@@ -16,6 +17,7 @@ import tamago.server.core.running.application.service.RunningQueryService
 class RunningFacade(
     private val runningCommandService: RunningCommandService,
     private val runningQueryService: RunningQueryService,
+    private val monsterCommandUseCase: MonsterCommandUseCase,
     private val monsterQueryUseCase: MonsterQueryUseCase,
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
@@ -25,17 +27,20 @@ class RunningFacade(
 
         publishRunningCompletedEvent(command)
 
-        // 같이 뛴 몬스터의 진화 체인 조회하고 현재 몬스터 추출
+        // 같이 뛴 몬스터의 진화 체인 조회
         val ownedMonster = monsterQueryUseCase.getOwnedMonster(command.ownedMonsterId)
         val evolutionChain = monsterQueryUseCase.getEvolutionChain(ownedMonster.monsterId)
-        val currentMonster = evolutionChain.first { it.id == ownedMonster.monsterId }
+
+        // 획득한 경험치 계산 및 저장
+        val earnedXp = evolutionChain.first { it.id == ownedMonster.monsterId }
+            .evolutionPolicy?.calculateXp(command.distance) ?: 0
+        monsterCommandUseCase.addEarnedXp(ownedMonster, earnedXp)
 
         return RunningFinishQueryDto.of(
             running = running,
             ownedMonster = ownedMonster,
-            currentMonster = currentMonster,
             evolutionChain = evolutionChain,
-            distance = command.distance,
+            earnedXp = earnedXp,
             startedAt = command.startedAt,
             finishedAt = command.finishedAt,
         )

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -9,8 +9,6 @@ import tamago.server.core.monster.MonsterQueryUseCase
 import tamago.server.core.running.domain.port.inbound.command.SaveRunningCommandDto
 import tamago.server.core.running.domain.port.inbound.query.MonthlyRunningQueryDto
 import tamago.server.core.running.domain.port.inbound.query.RunningFinishQueryDto
-import java.time.Duration
-
 @Component
 class RunningFacade(
     private val runningCommandUseCase: RunningCommandUseCase,
@@ -22,34 +20,29 @@ class RunningFacade(
     fun saveRunningData(command: SaveRunningCommandDto): RunningFinishQueryDto {
         val running = runningCommandUseCase.save(command)
 
-        applicationEventPublisher.publishEvent(
-            RunningCompletedEvent(
-                userId = command.userId,
-                startedAt = command.startedAt,
-            ),
-        )
+        publishRunningCompletedEvent(command)
 
         val ownedMonster = monsterQueryUseCase.getOwnedMonster(command.ownedMonsterId)
         val evolutionChain = monsterQueryUseCase.getEvolutionChain(ownedMonster.monsterId)
         val currentMonster = evolutionChain.first { it.id == ownedMonster.monsterId }
 
-        val elapsedSeconds = Duration.between(command.startedAt, command.finishedAt).seconds.toInt()
+        return RunningFinishQueryDto.of(
+            running = running,
+            ownedMonster = ownedMonster,
+            currentMonster = currentMonster,
+            evolutionChain = evolutionChain,
+            distance = command.distance,
+            startedAt = command.startedAt,
+            finishedAt = command.finishedAt,
+        )
+    }
 
-        return RunningFinishQueryDto(
-            pace = running.pace?.toInt() ?: 0,
-            cadence = running.cadence ?: 0,
-            elapsedTime = elapsedSeconds,
-            totalCalories = running.calories ?: 0,
-            originXp = ownedMonster.havingXp ?: 0,
-            earnedXp = currentMonster.evolutionPolicy?.calculateXp(command.distance) ?: 0, // TODO: earnedXp 저장
-            evolutionStages = evolutionChain.mapIndexed { index, monster ->
-                RunningFinishQueryDto.EvolutionStageDto(
-                    stage = index + 1,
-                    monsterId = monster.id!!.value,
-                    evolutionXp = monster.evolutionXp,
-                    current = monster.id == ownedMonster.monsterId,
-                )
-            },
+    private fun publishRunningCompletedEvent(command: SaveRunningCommandDto) {
+        applicationEventPublisher.publishEvent(
+            RunningCompletedEvent(
+                userId = command.userId,
+                startedAt = command.startedAt,
+            ),
         )
     }
 

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -25,6 +25,7 @@ class RunningFacade(
 
         publishRunningCompletedEvent(command)
 
+        // 같이 뛴 몬스터의 진화 체인 조회하고 현재 몬스터 추출
         val ownedMonster = monsterQueryUseCase.getOwnedMonster(command.ownedMonsterId)
         val evolutionChain = monsterQueryUseCase.getEvolutionChain(ownedMonster.monsterId)
         val currentMonster = evolutionChain.first { it.id == ownedMonster.monsterId }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -9,16 +9,19 @@ import tamago.server.core.monster.MonsterQueryUseCase
 import tamago.server.core.running.domain.port.inbound.command.SaveRunningCommandDto
 import tamago.server.core.running.domain.port.inbound.query.MonthlyRunningQueryDto
 import tamago.server.core.running.domain.port.inbound.query.RunningFinishQueryDto
+import tamago.server.core.running.application.service.RunningCommandService
+import tamago.server.core.running.application.service.RunningQueryService
+
 @Component
 class RunningFacade(
-    private val runningCommandUseCase: RunningCommandUseCase,
-    private val runningQueryUseCase: RunningQueryUseCase,
+    private val runningCommandService: RunningCommandService,
+    private val runningQueryService: RunningQueryService,
     private val monsterQueryUseCase: MonsterQueryUseCase,
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional
     fun saveRunningData(command: SaveRunningCommandDto): RunningFinishQueryDto {
-        val running = runningCommandUseCase.save(command)
+        val running = runningCommandService.save(command)
 
         publishRunningCompletedEvent(command)
 
@@ -48,7 +51,7 @@ class RunningFacade(
 
     @Transactional(readOnly = true)
     fun getMonthlyRunningData(userId: UserId, year: Int, month: Int): MonthlyRunningQueryDto {
-        val runnings = runningQueryUseCase.getMonthlyRunnings(userId, year, month)
+        val runnings = runningQueryService.getMonthlyRunnings(userId, year, month)
 
         // ownedMonsterId → monsterId 매핑 (distinct)
         val ownedMonsterIds = runnings.map { it.ownedMonsterId }.distinct()

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -24,8 +24,9 @@ class RunningFacade(
     @Transactional
     fun saveRunningData(command: SaveRunningCommandDto): RunningFinishQueryDto {
         val running = runningCommandService.save(command)
+        val totalDistance = runningQueryService.getTotalDistance(command.userId)
 
-        publishRunningCompletedEvent(command)
+        publishRunningCompletedEvent(command, totalDistance)
 
         // 같이 뛴 몬스터의 진화 체인 조회
         val ownedMonster = monsterQueryUseCase.getOwnedMonster(command.ownedMonsterId)
@@ -46,11 +47,12 @@ class RunningFacade(
         )
     }
 
-    private fun publishRunningCompletedEvent(command: SaveRunningCommandDto) {
+    private fun publishRunningCompletedEvent(command: SaveRunningCommandDto, totalDistance: Double) {
         applicationEventPublisher.publishEvent(
             RunningCompletedEvent(
                 userId = command.userId,
                 startedAt = command.startedAt,
+                totalDistance = totalDistance,
             ),
         )
     }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningQueryUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningQueryUseCase.kt
@@ -1,8 +1,4 @@
 package tamago.server.core.running
 
-import tamago.server.core.common.vo.UserId
-import tamago.server.core.running.domain.aggregate.Running
-
 interface RunningQueryUseCase {
-    fun getMonthlyRunnings(userId: UserId, year: Int, month: Int): List<Running>
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningCommandService.kt
@@ -15,7 +15,7 @@ class RunningCommandService(
     private val runningPersistencePort: RunningPersistencePort,
 ) : RunningCommandUseCase {
 
-    override fun save(command: SaveRunningCommandDto): Running {
+    fun save(command: SaveRunningCommandDto): Running {
         if (command.distance < 0 || !command.finishedAt.isAfter(command.startedAt)) {
             throw InvalidRunningDataException()
         }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningQueryService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningQueryService.kt
@@ -13,4 +13,7 @@ class RunningQueryService(
 
     fun getMonthlyRunnings(userId: UserId, year: Int, month: Int): List<Running> =
         runningPersistencePort.findAllByUserIdAndMonth(userId, year, month)
+
+    fun getTotalDistance(userId: UserId): Double =
+        runningPersistencePort.sumDistanceByUserId(userId)
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningQueryService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningQueryService.kt
@@ -11,6 +11,6 @@ class RunningQueryService(
     private val runningPersistencePort: RunningPersistencePort,
 ) : RunningQueryUseCase {
 
-    override fun getMonthlyRunnings(userId: UserId, year: Int, month: Int): List<Running> =
+    fun getMonthlyRunnings(userId: UserId, year: Int, month: Int): List<Running> =
         runningPersistencePort.findAllByUserIdAndMonth(userId, year, month)
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/event/RunningCompletedEvent.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/event/RunningCompletedEvent.kt
@@ -6,4 +6,5 @@ import java.time.LocalDateTime
 data class RunningCompletedEvent(
     val userId: UserId,
     val startedAt: LocalDateTime,
+    val totalDistance: Double,
 )

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/RunningFinishQueryDto.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/RunningFinishQueryDto.kt
@@ -1,5 +1,11 @@
 package tamago.server.core.running.domain.port.inbound.query
 
+import tamago.server.core.monster.domain.aggregate.Monster
+import tamago.server.core.monster.domain.aggregate.OwnedMonster
+import tamago.server.core.running.domain.aggregate.Running
+import java.time.Duration
+import java.time.LocalDateTime
+
 data class RunningFinishQueryDto(
     val pace: Int,
     val cadence: Int,
@@ -15,4 +21,35 @@ data class RunningFinishQueryDto(
         val evolutionXp: Int?,
         val current: Boolean,
     )
+
+    companion object {
+        fun of(
+            running: Running,
+            ownedMonster: OwnedMonster,
+            currentMonster: Monster,
+            evolutionChain: List<Monster>,
+            distance: Double,
+            startedAt: LocalDateTime,
+            finishedAt: LocalDateTime,
+        ): RunningFinishQueryDto {
+            val elapsedSeconds = Duration.between(startedAt, finishedAt).seconds.toInt()
+
+            return RunningFinishQueryDto(
+                pace = running.pace?.toInt() ?: 0,
+                cadence = running.cadence ?: 0,
+                elapsedTime = elapsedSeconds,
+                totalCalories = running.calories ?: 0,
+                originXp = ownedMonster.havingXp ?: 0,
+                earnedXp = currentMonster.evolutionPolicy?.calculateXp(distance) ?: 0, // TODO: earnedXp 저장
+                evolutionStages = evolutionChain.mapIndexed { index, monster ->
+                    EvolutionStageDto(
+                        stage = index + 1,
+                        monsterId = monster.id!!.value,
+                        evolutionXp = monster.evolutionXp,
+                        current = monster.id == ownedMonster.monsterId,
+                    )
+                },
+            )
+        }
+    }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/RunningFinishQueryDto.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/RunningFinishQueryDto.kt
@@ -26,9 +26,8 @@ data class RunningFinishQueryDto(
         fun of(
             running: Running,
             ownedMonster: OwnedMonster,
-            currentMonster: Monster,
             evolutionChain: List<Monster>,
-            distance: Double,
+            earnedXp: Int,
             startedAt: LocalDateTime,
             finishedAt: LocalDateTime,
         ): RunningFinishQueryDto {
@@ -40,7 +39,7 @@ data class RunningFinishQueryDto(
                 elapsedTime = elapsedSeconds,
                 totalCalories = running.calories ?: 0,
                 originXp = ownedMonster.havingXp ?: 0,
-                earnedXp = currentMonster.evolutionPolicy?.calculateXp(distance) ?: 0, // TODO: earnedXp 저장
+                earnedXp = earnedXp,
                 evolutionStages = evolutionChain.mapIndexed { index, monster ->
                     EvolutionStageDto(
                         stage = index + 1,

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/outbound/RunningPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/outbound/RunningPersistencePort.kt
@@ -6,4 +6,5 @@ import tamago.server.core.running.domain.aggregate.Running
 interface RunningPersistencePort {
     fun save(running: Running): Running
     fun findAllByUserIdAndMonth(userId: UserId, year: Int, month: Int): List<Running>
+    fun sumDistanceByUserId(userId: UserId): Double
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/repository/RunningPersistenceAdapter.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/repository/RunningPersistenceAdapter.kt
@@ -1,15 +1,22 @@
 package tamago.server.core.running.infrastructure.repository
 
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Repository
+import tamago.server.core.common.jdsl.findOne
 import tamago.server.core.common.vo.UserId
 import tamago.server.core.running.domain.aggregate.Running
 import tamago.server.core.running.domain.port.outbound.RunningPersistencePort
+import tamago.server.core.running.infrastructure.entity.RunningEntity
 import tamago.server.core.running.infrastructure.mapper.RunningMapper
 import java.time.LocalDate
 
 @Repository
 class RunningPersistenceAdapter(
     private val runningJpaRepository: RunningJpaRepository,
+    private val entityManager: EntityManager,
+    private val jpqlRenderContext: JpqlRenderContext,
 ) : RunningPersistencePort {
 
     override fun save(running: Running): Running =
@@ -25,5 +32,17 @@ class RunningPersistenceAdapter(
                 monthEnd = monthEnd,
             )
             .mapNotNull { RunningMapper.toDomain(it) }
+    }
+
+    override fun sumDistanceByUserId(userId: UserId): Double {
+        val query = jpql {
+            select(coalesce(sum(path(RunningEntity::distance)), 0.0))
+                .from(entity(RunningEntity::class))
+                .where(
+                    path(RunningEntity::userId).equal(userId.value)
+                        .and(path(RunningEntity::deletedAt).isNull()),
+                )
+        }
+        return entityManager.findOne<Double>(query, jpqlRenderContext) ?: 0.0
     }
 }

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/api/MonsterApi.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/api/MonsterApi.kt
@@ -14,4 +14,7 @@ interface MonsterApi {
 
     @Operation(summary = "해금된 몬스터 목록 조회", description = "해금된 몬스터(알) 목록을 조회합니다.")
     fun getUnlockedMonsters(user: User): CustomResponse<List<UnlockedMonsterResponse>>
+
+    @Operation(summary = "해금된 몬스터 소유", description = "해금된 몬스터를 소유 상태로 변경합니다.")
+    fun ownMonster(user: User, ownedMonsterId: Long): CustomResponse<Unit>
 }

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/api/MonsterApi.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/api/MonsterApi.kt
@@ -5,9 +5,13 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import tamago.server.core.user.domain.aggregate.User
 import tamago.server.gateway.common.response.CustomResponse
 import tamago.server.gateway.presentation.monster.v1.response.MonsterDexResponse
+import tamago.server.gateway.presentation.monster.v1.response.UnlockedMonsterResponse
 
 @Tag(name = "Monster API", description = "몬스터 도감 API")
 interface MonsterApi {
     @Operation(summary = "전체 몬스터 도감 조회", description = "전체 몬스터 캐릭터 도감 정보를 조회합니다.")
     fun getMonsterDex(user: User): CustomResponse<List<MonsterDexResponse>>
+
+    @Operation(summary = "해금된 몬스터 목록 조회", description = "해금된 몬스터(알) 목록을 조회합니다.")
+    fun getUnlockedMonsters(user: User): CustomResponse<List<UnlockedMonsterResponse>>
 }

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
@@ -45,7 +45,7 @@ class MonsterController(
         @CurrentUser user: User,
         @PathVariable ownedMonsterId: Long,
     ): CustomResponse<Unit> {
-        monsterFacade.ownMonster(OwnedMonsterId(ownedMonsterId))
+        monsterFacade.ownMonster(OwnedMonsterId(ownedMonsterId), user.id!!)
         return CustomResponse.ok()
     }
 }

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
@@ -2,9 +2,12 @@ package tamago.server.gateway.presentation.monster.v1.controller
 
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 import tamago.server.core.monster.MonsterFacade
 import tamago.server.core.monster.MonsterQueryUseCase
+import tamago.server.core.monster.domain.vo.OwnedMonsterId
 import tamago.server.core.user.domain.aggregate.User
 import tamago.server.gateway.common.annotation.CurrentUser
 import tamago.server.gateway.common.response.CustomResponse
@@ -34,5 +37,15 @@ class MonsterController(
     ): CustomResponse<List<UnlockedMonsterResponse>> {
         val unlockedMonsters = monsterQueryUseCase.getUnlockedMonsters(user.id!!)
         return CustomResponse.ok(unlockedMonsters.map { UnlockedMonsterResponse.from(it) })
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @PatchMapping("/api/v1/monsters/unlocked/{ownedMonsterId}")
+    override fun ownMonster(
+        @CurrentUser user: User,
+        @PathVariable ownedMonsterId: Long,
+    ): CustomResponse<Unit> {
+        monsterFacade.ownMonster(OwnedMonsterId(ownedMonsterId))
+        return CustomResponse.ok()
     }
 }

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
@@ -4,15 +4,18 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 import tamago.server.core.monster.MonsterFacade
+import tamago.server.core.monster.MonsterQueryUseCase
 import tamago.server.core.user.domain.aggregate.User
 import tamago.server.gateway.common.annotation.CurrentUser
 import tamago.server.gateway.common.response.CustomResponse
 import tamago.server.gateway.presentation.monster.v1.api.MonsterApi
 import tamago.server.gateway.presentation.monster.v1.response.MonsterDexResponse
+import tamago.server.gateway.presentation.monster.v1.response.UnlockedMonsterResponse
 
 @RestController
 class MonsterController(
     private val monsterFacade: MonsterFacade,
+    private val monsterQueryUseCase: MonsterQueryUseCase,
 ) : MonsterApi {
 
     @PreAuthorize("isAuthenticated()")
@@ -22,5 +25,14 @@ class MonsterController(
     ): CustomResponse<List<MonsterDexResponse>> {
         val result = monsterFacade.getMonsterDex(user.id!!)
         return CustomResponse.ok(result.map { MonsterDexResponse.from(it) })
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/api/v1/monsters/unlocked")
+    override fun getUnlockedMonsters(
+        @CurrentUser user: User,
+    ): CustomResponse<List<UnlockedMonsterResponse>> {
+        val unlockedMonsters = monsterQueryUseCase.getUnlockedMonsters(user.id!!)
+        return CustomResponse.ok(unlockedMonsters.map { UnlockedMonsterResponse.from(it) })
     }
 }

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/response/UnlockedMonsterResponse.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/response/UnlockedMonsterResponse.kt
@@ -1,0 +1,21 @@
+package tamago.server.gateway.presentation.monster.v1.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import tamago.server.core.monster.domain.aggregate.OwnedMonster
+
+@Schema(description = "해금된 몬스터(알) 응답")
+data class UnlockedMonsterResponse(
+    @field:Schema(description = "소유 몬스터 ID", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
+    val ownedMonsterId: Long,
+
+    @field:Schema(description = "몬스터 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    val monsterId: Long,
+) {
+    companion object {
+        fun from(ownedMonster: OwnedMonster): UnlockedMonsterResponse =
+            UnlockedMonsterResponse(
+                ownedMonsterId = ownedMonster.id!!.value,
+                monsterId = ownedMonster.monsterId.value,
+            )
+    }
+}


### PR DESCRIPTION
## Summary

>- #36 

러닝 완료 후 몬스터 알 해금 이벤트 구현하고 관련 API 설계
<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 러닝 완료 후 획득한 경험치 저장
- 러닝 완료 후 알 해금 이벤트 구현
- 해금된 몬스터 목록 조회 API
- 해금된 몬스터 적용하기 (소유) API

## ETC

러닝 경로 저장은 미구현
<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 러닝 거리 달성 시 몬스터 자동 해금 이벤트 처리 추가
  * 해금된 몬스터 목록 조회 API 추가(GET /api/v1/monsters/unlocked)
  * 해금된 몬스터를 보유로 전환하는 API 추가(PATCH /api/v1/monsters/unlocked/{id})
  * 몬스터 보유 상태(소유, 경험치) 관리 기능 및 경험치 누적 추가
  * 러닝 종료 결과 응답 구성 개선(획득 XP 등 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->