### PR TITLE
refactor: 몬스터별 러닝 통계 조회 추가 및 사소한 응답 필드 수정

### DIFF
--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -10,6 +10,7 @@ import tamago.server.core.running.application.service.RunningCommandService
 import tamago.server.core.running.application.service.RunningQueryService
 import tamago.server.core.running.domain.event.RunningCompletedEvent
 import tamago.server.core.running.domain.port.inbound.command.SaveRunningCommandDto
+import tamago.server.core.running.domain.port.inbound.query.MonsterRunningStatsQueryDto
 import tamago.server.core.running.domain.port.inbound.query.MonthlyRunningQueryDto
 import tamago.server.core.running.domain.port.inbound.query.RunningFinishQueryDto
 
@@ -65,6 +66,12 @@ class RunningFacade(
             ),
         )
     }
+
+    @Transactional(readOnly = true)
+    fun getStatsByOwnedMonsterIds(
+        userId: UserId,
+        ownedMonsterIds: List<Long>,
+    ): List<MonsterRunningStatsQueryDto> = runningQueryService.getStatsByOwnedMonsterIds(userId, ownedMonsterIds)
 
     @Transactional(readOnly = true)
     fun getMonthlyRunningData(

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -59,6 +59,7 @@ class RunningFacade(
             RunningCompletedEvent(
                 userId = command.userId,
                 startedAt = command.startedAt,
+                distance = command.distance,
                 totalDistance = totalDistance,
                 totalDurationMinutes = totalDurationMinutes,
             ),

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningQueryUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningQueryUseCase.kt
@@ -1,8 +1,14 @@
 package tamago.server.core.running
 
 import tamago.server.core.common.vo.UserId
+import tamago.server.core.running.domain.port.inbound.query.MonsterRunningStatsQueryDto
 import java.time.LocalDateTime
 
 interface RunningQueryUseCase {
     fun getLastFinishedAt(userId: UserId): LocalDateTime?
+
+    fun getStatsByOwnedMonsterIds(
+        userId: UserId,
+        ownedMonsterIds: List<Long>,
+    ): List<MonsterRunningStatsQueryDto>
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningQueryService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/application/service/RunningQueryService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import tamago.server.core.common.vo.UserId
 import tamago.server.core.running.RunningQueryUseCase
 import tamago.server.core.running.domain.aggregate.Running
+import tamago.server.core.running.domain.port.inbound.query.MonsterRunningStatsQueryDto
 import tamago.server.core.running.domain.port.outbound.RunningPersistencePort
 import java.time.LocalDateTime
 
@@ -23,4 +24,13 @@ class RunningQueryService(
     fun getTotalDistance(userId: UserId): Double = runningPersistencePort.sumDistanceByUserId(userId)
 
     fun getTotalDurationMinutes(userId: UserId): Long = runningPersistencePort.sumDurationMinutesByUserId(userId)
+
+    override fun getStatsByOwnedMonsterIds(
+        userId: UserId,
+        ownedMonsterIds: List<Long>,
+    ): List<MonsterRunningStatsQueryDto> =
+        runningPersistencePort.findStatsByUserIdAndOwnedMonsterIds(
+            userId,
+            ownedMonsterIds,
+        )
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/event/RunningCompletedEvent.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/event/RunningCompletedEvent.kt
@@ -6,6 +6,7 @@ import java.time.LocalDateTime
 data class RunningCompletedEvent(
     val userId: UserId,
     val startedAt: LocalDateTime,
+    val distance: Double,
     val totalDistance: Double,
     val totalDurationMinutes: Long,
 )

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/MonsterRunningStatsQueryDto.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/MonsterRunningStatsQueryDto.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.running.domain.port.inbound.query
+
+data class MonsterRunningStatsQueryDto(
+    val ownedMonsterId: Long,
+    val totalDistance: Double,
+    val runCount: Int,
+    val totalTimeMinutes: Long,
+)

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/outbound/RunningPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/outbound/RunningPersistencePort.kt
@@ -2,6 +2,7 @@ package tamago.server.core.running.domain.port.outbound
 
 import tamago.server.core.common.vo.UserId
 import tamago.server.core.running.domain.aggregate.Running
+import tamago.server.core.running.domain.port.inbound.query.MonsterRunningStatsQueryDto
 
 interface RunningPersistencePort {
     fun save(running: Running): Running
@@ -17,4 +18,9 @@ interface RunningPersistencePort {
     fun sumDistanceByUserId(userId: UserId): Double
 
     fun sumDurationMinutesByUserId(userId: UserId): Long
+
+    fun findStatsByUserIdAndOwnedMonsterIds(
+        userId: UserId,
+        ownedMonsterIds: List<Long>,
+    ): List<MonsterRunningStatsQueryDto>
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/repository/RunningPersistenceAdapter.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/repository/RunningPersistenceAdapter.kt
@@ -4,9 +4,11 @@ import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
 import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Repository
+import tamago.server.core.common.jdsl.findAll
 import tamago.server.core.common.jdsl.findOne
 import tamago.server.core.common.vo.UserId
 import tamago.server.core.running.domain.aggregate.Running
+import tamago.server.core.running.domain.port.inbound.query.MonsterRunningStatsQueryDto
 import tamago.server.core.running.domain.port.outbound.RunningPersistencePort
 import tamago.server.core.running.infrastructure.entity.RunningEntity
 import tamago.server.core.running.infrastructure.mapper.RunningMapper
@@ -68,5 +70,39 @@ class RunningPersistenceAdapter(
             }
         val totalSeconds = entityManager.findOne<Long>(query, jpqlRenderContext) ?: 0L
         return totalSeconds / 60
+    }
+
+    override fun findStatsByUserIdAndOwnedMonsterIds(
+        userId: UserId,
+        ownedMonsterIds: List<Long>,
+    ): List<MonsterRunningStatsQueryDto> {
+        if (ownedMonsterIds.isEmpty()) return emptyList()
+
+        val query =
+            jpql {
+                selectNew<RunningStatsByMonsterRow>(
+                    path(RunningEntity::ownedMonsterId),
+                    coalesce(sum(path(RunningEntity::distance)), 0.0),
+                    count(path(RunningEntity::id)),
+                    coalesce(sum(path(RunningEntity::elapsedTime)), 0L),
+                ).from(entity(RunningEntity::class))
+                    .where(
+                        path(RunningEntity::userId)
+                            .equal(userId.value)
+                            .and(path(RunningEntity::ownedMonsterId).`in`(ownedMonsterIds))
+                            .and(path(RunningEntity::deletedAt).isNull()),
+                    ).groupBy(path(RunningEntity::ownedMonsterId))
+            }
+
+        val rows = entityManager.findAll<RunningStatsByMonsterRow>(query, jpqlRenderContext)
+
+        return rows.map { row ->
+            MonsterRunningStatsQueryDto(
+                ownedMonsterId = row.ownedMonsterId,
+                totalDistance = row.totalDistance,
+                runCount = row.runCount.toInt(),
+                totalTimeMinutes = row.totalElapsedSeconds / 60,
+            )
+        }
     }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/repository/RunningStatsByMonsterRow.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/infrastructure/repository/RunningStatsByMonsterRow.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.running.infrastructure.repository
+
+data class RunningStatsByMonsterRow(
+    val ownedMonsterId: Long,
+    val totalDistance: Double,
+    val runCount: Long,
+    val totalElapsedSeconds: Long,
+)

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/application/event/UserEventListener.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/application/event/UserEventListener.kt
@@ -1,0 +1,29 @@
+package tamago.server.core.user.application.event
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionalEventListener
+import tamago.server.core.running.domain.event.RunningCompletedEvent
+import tamago.server.core.user.application.service.UserCommandService
+import tamago.server.core.user.application.service.UserQueryService
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class UserEventListener(
+    private val userQueryService: UserQueryService,
+    private val userCommandService: UserCommandService,
+) {
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun onRunningCompleted(event: RunningCompletedEvent) {
+        try {
+            val user = userQueryService.get(event.userId)
+            userCommandService.addRunningDistance(user, event.distance)
+        } catch (e: Exception) {
+            logger.error(e) { "러닝 완료 후 총 거리 업데이트 오류 - userId: ${event.userId}" }
+        }
+    }
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/application/service/UserCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/application/service/UserCommandService.kt
@@ -80,6 +80,14 @@ class UserCommandService(
         userPersistencePort.save(user)
     }
 
+    fun addRunningDistance(
+        user: User,
+        distance: Double,
+    ) {
+        user.addRunningDistance(distance)
+        userPersistencePort.save(user)
+    }
+
     private fun createSocialUser(command: LoginCommandDto): User {
         val savedUser = userPersistencePort.save(User.create(command.email, command.provider, command.externalId))
         val userId = savedUser.id ?: throw UserSaveErrorException()

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/domain/aggregate/User.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/domain/aggregate/User.kt
@@ -46,6 +46,10 @@ class User(
         this.runningData = runningData.updateGoalKilo(goalKilo)
     }
 
+    fun addRunningDistance(distance: Double) {
+        this.runningData = runningData.addKilo(distance)
+    }
+
     fun isOnboarded(): Boolean = !nickname.isNullOrBlank() && runningData.goalKilo != null
 
     companion object {

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/common/configuration/SecurityConfig.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/common/configuration/SecurityConfig.kt
@@ -90,6 +90,7 @@ class SecurityConfig(
                 "/api/v1/auth/**",
                 "/error",
                 "/api/v1/monsters/assets",
+                "/api/v1/monsters/assets/check-updates",
             )
     }
 }

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
@@ -99,6 +99,7 @@ class MonsterController(
     }
 
     @Operation(summary = "몬스터 에셋 변경 여부 확인", description = "마지막 로그인 이후 몬스터 에셋이 변경되었는지 확인합니다.")
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/api/v1/monsters/assets/check-updates")
     fun checkMonsterAssetUpdates(
         @CurrentUser user: User,

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
@@ -99,7 +99,6 @@ class MonsterController(
     }
 
     @Operation(summary = "몬스터 에셋 변경 여부 확인", description = "마지막 로그인 이후 몬스터 에셋이 변경되었는지 확인합니다.")
-    @PreAuthorize("isAuthenticated()")
     @GetMapping("/api/v1/monsters/assets/check-updates")
     fun checkMonsterAssetUpdates(
         @CurrentUser user: User,

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/controller/RunningController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/controller/RunningController.kt
@@ -44,7 +44,7 @@ class RunningController(
     @GetMapping("/api/v1/running/stats")
     fun getStatsByOwnedMonsterIds(
         @CurrentUser user: User,
-        @RequestParam @Parameter(description = "소유 몬스터 ID 목록", example = "1,2,3") ownedMonsterIds: List<Long>,
+        @RequestParam @Parameter(description = "소유 몬스터 ID 목록", example = "[1,2,3]") ownedMonsterIds: List<Long>,
     ): CustomResponse<List<MonsterRunningStatsResponse>> {
         val result = runningFacade.getStatsByOwnedMonsterIds(user.id!!, ownedMonsterIds)
         return CustomResponse.ok(result.map { MonsterRunningStatsResponse.from(it) })

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/controller/RunningController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/controller/RunningController.kt
@@ -18,6 +18,7 @@ import tamago.server.gateway.common.annotation.CurrentUser
 import tamago.server.gateway.common.response.CustomResponse
 import tamago.server.gateway.presentation.running.v1.request.RunningRequest
 import tamago.server.gateway.presentation.running.v1.request.toCommand
+import tamago.server.gateway.presentation.running.v1.response.MonsterRunningStatsResponse
 import tamago.server.gateway.presentation.running.v1.response.MonthlyRunningResponse
 import tamago.server.gateway.presentation.running.v1.response.RunningFinishResponse
 
@@ -36,6 +37,17 @@ class RunningController(
     ): CustomResponse<RunningFinishResponse> {
         val result = runningFacade.saveRunningData(request.toCommand(user.id!!, user.weight))
         return CustomResponse.created(RunningFinishResponse.from(result))
+    }
+
+    @Operation(summary = "몬스터별 러닝 통계 조회", description = "소유 몬스터 ID 목록으로 몬스터별 러닝 통계를 반환합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/api/v1/running/stats")
+    fun getStatsByOwnedMonsterIds(
+        @CurrentUser user: User,
+        @RequestParam @Parameter(description = "소유 몬스터 ID 목록", example = "1,2,3") ownedMonsterIds: List<Long>,
+    ): CustomResponse<List<MonsterRunningStatsResponse>> {
+        val result = runningFacade.getStatsByOwnedMonsterIds(user.id!!, ownedMonsterIds)
+        return CustomResponse.ok(result.map { MonsterRunningStatsResponse.from(it) })
     }
 
     @Operation(summary = "월별 러닝 데이터 조회", description = "해당 월의 일별 러닝 데이터와 월간 요약을 반환합니다.")

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/response/MonsterRunningStatsResponse.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/response/MonsterRunningStatsResponse.kt
@@ -1,0 +1,26 @@
+package tamago.server.gateway.presentation.running.v1.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import tamago.server.core.running.domain.port.inbound.query.MonsterRunningStatsQueryDto
+
+@Schema(description = "몬스터별 러닝 통계 응답")
+data class MonsterRunningStatsResponse(
+    @field:Schema(description = "소유 몬스터 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    val ownedMonsterId: Long,
+    @field:Schema(description = "총 거리 (km)", example = "42.5", requiredMode = Schema.RequiredMode.REQUIRED)
+    val totalDistance: Double,
+    @field:Schema(description = "러닝 횟수", example = "12", requiredMode = Schema.RequiredMode.REQUIRED)
+    val runCount: Int,
+    @field:Schema(description = "총 러닝 시간 (분)", example = "450", requiredMode = Schema.RequiredMode.REQUIRED)
+    val totalTimeMinutes: Long,
+) {
+    companion object {
+        fun from(dto: MonsterRunningStatsQueryDto): MonsterRunningStatsResponse =
+            MonsterRunningStatsResponse(
+                ownedMonsterId = dto.ownedMonsterId,
+                totalDistance = dto.totalDistance,
+                runCount = dto.runCount,
+                totalTimeMinutes = dto.totalTimeMinutes,
+            )
+    }
+}


### PR DESCRIPTION
## Summary

>- #46 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 러닝 완료 시 누적 거리 저장되게 수정
- 앱 리소스 확인용 API 에서 권한 헤더 제거
- 몬스터별 러닝 통계 조회 API

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 보유한 몬스터별 러닝 통계 조회용 신규 API 엔드포인트 추가 (/api/v1/running/stats).
  * 러닝 완료 이벤트에 거리 정보 포함.
  * 러닝 완료 시 사용자 총 러닝 거리를 자동으로 누적·업데이트하는 기능 추가.

* **Chores**
  * 몬스터 자산 업데이트 확인 엔드포인트를 인증 없이 접근 가능하도록 허용 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->