### PR TITLE
refactor: 월 러닝 데이터 응답 시 해당 날짜 마지막 러닝에 사용된 몬스터 ID 반환하도록 필드 추가

### DIFF
--- a/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/RunningFacade.kt
@@ -88,9 +88,11 @@ class RunningFacade(
                 .entries
                 .sortedBy { it.key }
                 .map { (date, runs) ->
+                    val sortedRuns = runs.sortedBy { it.startedAt }
                     MonthlyRunningQueryDto.DailyRunningDto(
                         date = date,
-                        runs = runs.map { running -> MonthlyRunningQueryDto.RunDetailDto.from(running) },
+                        runs = sortedRuns.map { running -> MonthlyRunningQueryDto.RunDetailDto.from(running) },
+                        lastRunOwnedMonsterId = sortedRuns.last().ownedMonsterId.value,
                     )
                 }
 

--- a/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/MonthlyRunningQueryDto.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/running/domain/port/inbound/query/MonthlyRunningQueryDto.kt
@@ -11,6 +11,7 @@ data class MonthlyRunningQueryDto(
     data class DailyRunningDto(
         val date: LocalDate,
         val runs: List<RunDetailDto>,
+        val lastRunOwnedMonsterId: Long,
     )
 
     data class RunDetailDto(

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/response/MonthlyRunningResponse.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/running/v1/response/MonthlyRunningResponse.kt
@@ -17,12 +17,19 @@ data class MonthlyRunningResponse(
         val date: LocalDate,
         @field:Schema(description = "해당 날짜의 러닝 목록", requiredMode = Schema.RequiredMode.REQUIRED)
         val runs: List<RunDetailResponse>,
+        @field:Schema(
+            description = "해당 날짜의 마지막 러닝에 사용된 보유 몬스터 ID",
+            example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+        )
+        val lastRunOwnedMonsterId: Long,
     ) {
         companion object {
             fun from(dto: MonthlyRunningQueryDto.DailyRunningDto): DailyRunningResponse =
                 DailyRunningResponse(
                     date = dto.date,
                     runs = dto.runs.map { RunDetailResponse.from(it) },
+                    lastRunOwnedMonsterId = dto.lastRunOwnedMonsterId,
                 )
         }
     }


### PR DESCRIPTION
## Summary

>- #50

월 러닝 데이터 응답 시 해당 날짜 마지막 러닝에 사용된 몬스터 ID 반환하도록 필드 추가

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 해당 날짜의 마지막 러닝 데이터 기준으로 ownedMonsterId 반환
- 응답 DTO 수정

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

- 월간 러닝 조회 응답에 각 날짜별 마지막 러닝의 소유 몬스터 ID 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->