### PR TITLE
fix: FCM 자격 증명 파일 열기 로직 개선 및 에러 핸들링

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -43,8 +43,6 @@ jobs:
           key: ${{ secrets.SERVER_PASSWORD }}
           port: ${{ secrets.SERVER_PORT }}
           script: |
-            set -a && source .env && set +a
-
             docker rm -f tamago-server || true
 
             docker pull ${{ secrets.DOCKER_USERNAME }}/tamago-server:latest
@@ -53,7 +51,7 @@ jobs:
               --name tamago-server \
               --env-file .env \
               -e SPRING_PROFILES_ACTIVE=dev \
-              -v $FCM_CREDENTIALS_PATH:/app/firebase-service-account.json:ro \
+              -v ${{ secrets.FCM_CREDENTIALS_PATH }}:/app/firebase-service-account.json:ro \
               -p 8080:8080 \
               --network tamago \
               --cpus="0.5" \

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -43,6 +43,8 @@ jobs:
           key: ${{ secrets.SERVER_PASSWORD }}
           port: ${{ secrets.SERVER_PORT }}
           script: |
+            set -a && source .env && set +a
+
             docker rm -f tamago-server || true
 
             docker pull ${{ secrets.DOCKER_USERNAME }}/tamago-server:latest
@@ -51,6 +53,7 @@ jobs:
               --name tamago-server \
               --env-file .env \
               -e SPRING_PROFILES_ACTIVE=dev \
+              -v $FCM_CREDENTIALS_PATH:/app/firebase-service-account.json:ro \
               -p 8080:8080 \
               --network tamago \
               --cpus="0.5" \

--- a/tamago-gateway/src/main/resources/application.yml
+++ b/tamago-gateway/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
       - oauth.yml
       - modulith.yml
       - aws.yml
+      - fcm.yml
   servlet:
     multipart:
       max-file-size: 10MB

--- a/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
+++ b/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
@@ -30,7 +30,7 @@ class FirebaseConfig(
                 }
             } catch (e: Exception) {
                 throw IllegalStateException(
-                    "Failed to load Firebase credentials from: ${firebaseProperties.credentialsPath}",
+                    "Failed to load Firebase credentials from: ${firebaseProperties.credentialsPath} - ${e.message}",
                     e,
                 )
             }

--- a/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
+++ b/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
@@ -9,6 +9,9 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ClassPathResource
 import java.io.IOException
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Paths
 
 @Configuration
 @EnableConfigurationProperties(FirebaseProperties::class)
@@ -23,7 +26,7 @@ class FirebaseConfig(
 
         val credentials =
             try {
-                ClassPathResource(firebaseProperties.credentialsPath).inputStream.use {
+                openCredentialsStream(firebaseProperties.credentialsPath).use {
                     GoogleCredentials.fromStream(it)
                 }
             } catch (e: IOException) {
@@ -40,6 +43,14 @@ class FirebaseConfig(
                 .build()
 
         return FirebaseApp.initializeApp(options)
+    }
+
+    private fun openCredentialsStream(path: String): InputStream {
+        val filePath = Paths.get(path)
+        if (Files.exists(filePath)) {
+            return Files.newInputStream(filePath)
+        }
+        return ClassPathResource(path).inputStream
     }
 
     @Bean

--- a/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
+++ b/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
@@ -8,7 +8,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ClassPathResource
-import java.io.IOException
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -29,9 +28,9 @@ class FirebaseConfig(
                 openCredentialsStream(firebaseProperties.credentialsPath).use {
                     GoogleCredentials.fromStream(it)
                 }
-            } catch (e: IOException) {
+            } catch (e: Exception) {
                 throw IllegalStateException(
-                    "Firebase credentials file not found: ${firebaseProperties.credentialsPath}",
+                    "Failed to load Firebase credentials from: ${firebaseProperties.credentialsPath}",
                     e,
                 )
             }

--- a/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
+++ b/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
@@ -44,13 +44,12 @@ class FirebaseConfig(
         return FirebaseApp.initializeApp(options)
     }
 
-    private fun openCredentialsStream(path: String): InputStream {
-        val filePath = Paths.get(path)
-        if (Files.exists(filePath)) {
-            return Files.newInputStream(filePath)
+    private fun openCredentialsStream(path: String): InputStream =
+        try {
+            Files.newInputStream(Paths.get(path))
+        } catch (e: Exception) {
+            ClassPathResource(path).inputStream
         }
-        return ClassPathResource(path).inputStream
-    }
 
     @Bean
     fun firebaseMessaging(firebaseApp: FirebaseApp): FirebaseMessaging = FirebaseMessaging.getInstance(firebaseApp)


### PR DESCRIPTION
## Summary

>- 관련 있는 Issue를 태그해주세요.

FCM 자격 증명 파일 열기 로직 개선 및 에러 핸들링

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- FCM 자격 증명 파일 로드 분기 처리
- GitHub Actions에서 host path 주입 후 마운트
- FCM config 에러 핸들링

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Firebase 서비스 계정 자격증명을 파일 시스템에서 로드할 수 있도록 지원 추가
  * Firebase Cloud Messaging(FCM) 설정 통합 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->