### PR TITLE
chore:  Fargate 기반 프로덕션 배포 파이프라인 구축

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -69,3 +69,11 @@ jobs:
           cluster: ${{ secrets.ECS_CLUSTER }}
           wait-for-service-stability: true
           wait-for-minutes: 10
+
+      - name: "애플리케이션이 정상적으로 구동되었는지 확인한다."
+        uses: jtalk/url-health-check-action@v4
+        with:
+          url: https://prd.runtamago.shop/actuator/health
+          max-attempts: 10
+          retry-delay: 10s
+          retry-all: true

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -1,0 +1,71 @@
+name: Deploy to Production Server
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    environment: production
+
+    steps:
+      - name: "레포지토리에서 체크아웃한다."
+        uses: actions/checkout@v4
+
+      - name: "AWS 자격 증명을 구성한다."
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: "Amazon ECR에 로그인한다."
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: "도커 이미지를 빌드하고 ECR에 푸시한다."
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -f ./docker/DockerfileProd -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-22.04
+    environment: production
+
+    steps:
+      - name: "AWS 자격 증명을 구성한다."
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: "Amazon ECR에 로그인한다."
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: "ECS 태스크 정의를 업데이트한다."
+        id: render-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition-arn: ${{ secrets.ECS_TASK_DEFINITION_ARN }}
+          container-name: ${{ secrets.ECS_CONTAINER_NAME }}
+          image: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}
+
+      - name: "ECS Fargate 서비스에 배포한다."
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-task-def.outputs.task-definition }}
+          service: ${{ secrets.ECS_SERVICE }}
+          cluster: ${{ secrets.ECS_CLUSTER }}
+          wait-for-service-stability: true
+          wait-for-minutes: 10

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: production-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/docker/DockerfileProd
+++ b/docker/DockerfileProd
@@ -1,0 +1,19 @@
+# ---------- build stage ----------
+FROM gradle:8-jdk AS build
+WORKDIR /workspace
+
+COPY . .
+RUN ./gradlew :tamago-gateway:bootJar -x test --no-daemon
+
+# ---------- runtime stage ----------
+FROM eclipse-temurin:21-jre-alpine AS runtime
+
+RUN addgroup --system app && adduser --system --ingroup app app
+USER app
+WORKDIR /app
+
+COPY --from=build /workspace/tamago-gateway/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["sh","-c","java $JAVA_OPTS -jar /app/app.jar"]

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/UserFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/UserFacade.kt
@@ -8,6 +8,7 @@ import tamago.server.core.refreshtoken.RefreshTokenQueryUseCase
 import tamago.server.core.user.application.exception.EmailAlreadyExistsException
 import tamago.server.core.user.application.exception.InvalidCredentialsException
 import tamago.server.core.user.application.exception.UserSaveErrorException
+import tamago.server.core.user.application.exception.UserWithdrawnException
 import tamago.server.core.user.application.service.UserCommandService
 import tamago.server.core.user.application.service.UserQueryService
 import tamago.server.core.user.domain.port.inbound.command.LoginCommandDto
@@ -31,6 +32,10 @@ class UserFacade(
             ?: throw EmailAlreadyExistsException()
 
     fun socialLogin(command: LoginCommandDto): TokenQueryDto {
+        command
+            .takeUnless { userQueryService.existsDeletedByExternalId(it.provider, it.externalId) }
+            ?: throw UserWithdrawnException()
+
         val user =
             userQueryService.findByExternalId(command.provider, command.externalId)
                 ?: userCommandService.createSocialUser(command)

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/UserFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/UserFacade.kt
@@ -63,7 +63,11 @@ class UserFacade(
         }
 
         val userId = auth.userId ?: throw InvalidCredentialsException()
-        val user = userQueryService.get(userId)
+        val user =
+            userQueryService
+                .get(userId)
+                .takeUnless { it.deletedAt != null }
+                ?: throw UserWithdrawnException()
 
         val accessToken = jwtTokenProvider.generateAccessToken(userId, user.role.name)
         val refreshToken = jwtTokenProvider.generateRefreshToken(userId, user.role.name)

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/application/exception/UserExceptionCode.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/application/exception/UserExceptionCode.kt
@@ -12,6 +12,7 @@ enum class UserExceptionCode(
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_4040", "유저를 찾을 수 없습니다"),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "USER_4010", "이메일 또는 비밀번호가 올바르지 않습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER_4090", "이미 존재하는 이메일입니다."),
+    USER_WITHDRAWN(HttpStatus.FORBIDDEN, "USER_4030", "탈퇴한 유저입니다."),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/application/exception/UserWithdrawnException.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/application/exception/UserWithdrawnException.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.user.application.exception
+
+import tamago.server.core.common.exception.BusinessException
+
+class UserWithdrawnException :
+    BusinessException(
+        UserExceptionCode.USER_WITHDRAWN,
+    )

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/application/service/UserQueryService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/application/service/UserQueryService.kt
@@ -37,4 +37,9 @@ class UserQueryService(
     ): User? = userPersistencePort.findByExternalId(provider, externalId)
 
     override fun exists(email: String): Boolean = userPersistencePort.existsByEmail(email)
+
+    fun existsDeletedByExternalId(
+        provider: AuthProvider,
+        externalId: String,
+    ): Boolean = userPersistencePort.existsDeletedByExternalId(provider, externalId)
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/domain/port/outbound/UserPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/domain/port/outbound/UserPersistencePort.kt
@@ -17,4 +17,9 @@ interface UserPersistencePort {
     fun findByEmail(email: String): User?
 
     fun existsByEmail(email: String): Boolean
+
+    fun existsDeletedByExternalId(
+        provider: AuthProvider,
+        externalId: String,
+    ): Boolean
 }

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/common/configuration/SwaggerConfig.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/common/configuration/SwaggerConfig.kt
@@ -21,6 +21,7 @@ class SwaggerConfig(
             mapOf(
                 "local" to "http://localhost:8080",
                 "dev" to "https://dev.runtamago.shop",
+                "prod" to "https://prd.runtamago.shop",
             )
     }
 

--- a/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
+++ b/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ClassPathResource
+import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -25,12 +26,12 @@ class FirebaseConfig(
 
         val credentials =
             try {
-                openCredentialsStream(firebaseProperties.credentialsPath).use {
+                openCredentialsStream().use {
                     GoogleCredentials.fromStream(it)
                 }
             } catch (e: Exception) {
                 throw IllegalStateException(
-                    "Failed to load Firebase credentials from: ${firebaseProperties.credentialsPath} - ${e.message}",
+                    "Failed to load Firebase credentials - ${e.message}",
                     e,
                 )
             }
@@ -44,12 +45,19 @@ class FirebaseConfig(
         return FirebaseApp.initializeApp(options)
     }
 
-    private fun openCredentialsStream(path: String): InputStream =
-        try {
+    private fun openCredentialsStream(): InputStream {
+        val json = firebaseProperties.credentialsJson
+        if (json.isNotBlank()) {
+            return ByteArrayInputStream(json.toByteArray())
+        }
+
+        val path = firebaseProperties.credentialsPath
+        return try {
             Files.newInputStream(Paths.get(path))
         } catch (e: Exception) {
             ClassPathResource(path).inputStream
         }
+    }
 
     @Bean
     fun firebaseMessaging(firebaseApp: FirebaseApp): FirebaseMessaging = FirebaseMessaging.getInstance(firebaseApp)

--- a/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
+++ b/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseConfig.kt
@@ -46,9 +46,10 @@ class FirebaseConfig(
     }
 
     private fun openCredentialsStream(): InputStream {
-        val json = firebaseProperties.credentialsJson
+        val json = firebaseProperties.credentialsJson.trim().removeSurrounding("\"")
         if (json.isNotBlank()) {
-            return ByteArrayInputStream(json.toByteArray())
+            val unescaped = json.replace("\\n", "\n").replace("\\\"", "\"")
+            return ByteArrayInputStream(unescaped.toByteArray())
         }
 
         val path = firebaseProperties.credentialsPath

--- a/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseProperties.kt
+++ b/tamago-notification/src/main/kotlin/tamago/server/notification/FirebaseProperties.kt
@@ -4,5 +4,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "fcm")
 data class FirebaseProperties(
-    val credentialsPath: String,
+    val credentialsPath: String = "",
+    val credentialsJson: String = "",
 )

--- a/tamago-notification/src/main/resources/fcm.yml
+++ b/tamago-notification/src/main/resources/fcm.yml
@@ -1,2 +1,3 @@
 fcm:
   credentials-path: ${FCM_CREDENTIALS_PATH:firebase-service-account.json}
+  credentials-json: ${FIREBASE_CONFIG:}

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/user/repository/UserJpaRepository.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/user/repository/UserJpaRepository.kt
@@ -12,4 +12,9 @@ interface UserJpaRepository : JpaRepository<UserEntity, Long> {
     fun findByAuthsEmail(email: String): UserEntity?
 
     fun existsByAuthsEmail(email: String): Boolean
+
+    fun existsByAuthsProviderAndAuthsExternalIdAndDeletedAtIsNotNull(
+        provider: String,
+        externalId: String,
+    ): Boolean
 }

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/user/repository/UserPersistenceAdapter.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/user/repository/UserPersistenceAdapter.kt
@@ -26,4 +26,11 @@ class UserPersistenceAdapter(
     override fun findByEmail(email: String): User? = UserMapper.toDomain(userJpaRepository.findByAuthsEmail(email))
 
     override fun existsByEmail(email: String): Boolean = userJpaRepository.existsByAuthsEmail(email)
+
+    override fun existsDeletedByExternalId(
+        provider: AuthProvider,
+        externalId: String,
+    ): Boolean =
+        userJpaRepository
+            .existsByAuthsProviderAndAuthsExternalIdAndDeletedAtIsNotNull(provider.name, externalId)
 }

--- a/tamago-storage/src/main/resources/flyway.yml
+++ b/tamago-storage/src/main/resources/flyway.yml
@@ -30,5 +30,3 @@ spring:
   flyway:
     clean-disabled: true
     validate-on-migrate: true
-    locations:
-      - classpath:db/migration


### PR DESCRIPTION
## Summary

>- #59 

프로덕션 배포 파이프라인 구축

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 이메일 로그인 & 소셜 로그인 시 회원 탈퇴 여부 검증 로직 추가
- DockerfileProd 작성 및 ECS Fargate 기반 프로덕션 CD 파이프라인 구성
- 프로덕션 워크플로 실행에 대한 동시성 제어 추가

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 탈퇴한 계정으로의 로그인 시도 차단
  * 프로덕션 자동 배포(이미지 빌드·배포 및 헬스체크 포함) 파이프라인 추가
  * Firebase 자격증명에 인라인 JSON 입력 지원 및 구성 프로퍼티 추가
  * 프로덕션용 API 서버 URL(문서화) 추가

* **버그 수정**
  * 삭제된 사용자 상태 검증 강화

* **기타**
  * 프로덕션 DB 마이그레이션 설정 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->