### PR TITLE
fix: Opentelemetry 환경변수 값 조정하고 일부 쿼리에 JPA 메서드 쿼리 대신 Kotlin JDSL 사용

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -65,7 +65,7 @@ jobs:
         uses: jtalk/url-health-check-action@v4
         with:
           url: https://dev.runtamago.shop/actuator/health
-          max-attempts: 10
+          max-attempts: 20
           retry-delay: 10s
           retry-all: true
 

--- a/docker/DockerfileDev
+++ b/docker/DockerfileDev
@@ -23,5 +23,8 @@ COPY --from=build /workspace/tamago-gateway/build/libs/*.jar app.jar
 EXPOSE 8080
 
 ENV SENTRY_AUTO_INIT=false
+ENV OTEL_LOGS_EXPORTER=none
+ENV OTEL_METRICS_EXPORTER=none
+ENV OTEL_TRACES_EXPORTER=none
 
 ENTRYPOINT ["sh","-c","java -javaagent:/opt/sentry/agent.jar $JAVA_OPTS -jar /app/app.jar"]

--- a/docker/DockerfileProd
+++ b/docker/DockerfileProd
@@ -22,8 +22,9 @@ COPY --from=build /workspace/tamago-gateway/build/libs/*.jar app.jar
 
 EXPOSE 8080
 
+ENV SENTRY_AUTO_INIT=false
 ENV OTEL_LOGS_EXPORTER=none
 ENV OTEL_METRICS_EXPORTER=none
 ENV OTEL_TRACES_EXPORTER=none
 
-ENTRYPOINT ["sh","-c","java -javaagent:/opt/sentry/agent.jar -Dsentry.auto.init=false $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["sh","-c","java -javaagent:/opt/sentry/agent.jar $JAVA_OPTS -jar /app/app.jar"]

--- a/docker/DockerfileProd
+++ b/docker/DockerfileProd
@@ -22,4 +22,8 @@ COPY --from=build /workspace/tamago-gateway/build/libs/*.jar app.jar
 
 EXPOSE 8080
 
+ENV OTEL_LOGS_EXPORTER=none
+ENV OTEL_METRICS_EXPORTER=none
+ENV OTEL_TRACES_EXPORTER=none
+
 ENTRYPOINT ["sh","-c","java -javaagent:/opt/sentry/agent.jar -Dsentry.auto.init=false $JAVA_OPTS -jar /app/app.jar"]

--- a/tamago-aws/src/main/kotlin/tamago/server/aws/s3/AwsS3Client.kt
+++ b/tamago-aws/src/main/kotlin/tamago/server/aws/s3/AwsS3Client.kt
@@ -3,6 +3,7 @@ package tamago.server.aws.s3
 import org.springframework.stereotype.Component
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
@@ -128,6 +129,20 @@ class AwsS3Client(
                 .build()
 
         return s3Client.headObject(request).lastModified()
+    }
+
+    fun deleteObject(
+        bucketName: String,
+        key: String,
+    ) {
+        val request =
+            DeleteObjectRequest
+                .builder()
+                .bucket(bucketName)
+                .key(key)
+                .build()
+
+        s3Client.deleteObject(request)
     }
 
     fun putObject(

--- a/tamago-aws/src/main/kotlin/tamago/server/aws/s3/S3ImageProcessor.kt
+++ b/tamago-aws/src/main/kotlin/tamago/server/aws/s3/S3ImageProcessor.kt
@@ -87,6 +87,19 @@ class S3ImageProcessor(
         }
     }
 
+    override fun deleteFile(
+        prefix: String,
+        prefixId: Long,
+        fileName: String,
+    ) {
+        try {
+            val filePath = imageFileConstructor.imageFilePath(prefix, prefixId)
+            awsS3Client.deleteObject(awsProperties.s3.bucket, "$filePath/$fileName")
+        } catch (e: SdkException) {
+            throw S3Exception(e)
+        }
+    }
+
     private fun generateGetUrl(
         filePath: String,
         fileName: String,

--- a/tamago-core/src/main/kotlin/tamago/server/core/common/image/ImageProcessor.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/common/image/ImageProcessor.kt
@@ -33,4 +33,10 @@ interface ImageProcessor {
         fileBytes: ByteArray,
         fileName: String,
     ): UploadedImage
+
+    fun deleteFile(
+        prefix: String,
+        prefixId: Long,
+        fileName: String,
+    )
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
@@ -146,6 +146,22 @@ class MonsterFacade(
     }
 
     @Transactional
+    fun deleteMonsterAsset(
+        monsterId: MonsterId,
+        assetType: AssetType,
+    ) {
+        val asset = monsterQueryService.getMonsterAsset(monsterId, assetType)
+
+        imageProcessor.deleteFile(
+            prefix = ImagePrefix.MONSTER.value,
+            prefixId = monsterId.value,
+            fileName = asset.assetName!!,
+        )
+
+        monsterCommandService.hardDeleteMonsterAsset(asset)
+    }
+
+    @Transactional
     fun createOwnedMonster(
         monsterId: MonsterId,
         userId: UserId,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/MonsterFacade.kt
@@ -9,6 +9,8 @@ import tamago.server.core.common.vo.MonsterId
 import tamago.server.core.common.vo.UserId
 import tamago.server.core.monster.application.service.MonsterCommandService
 import tamago.server.core.monster.application.service.MonsterQueryService
+import tamago.server.core.monster.domain.aggregate.Monster
+import tamago.server.core.monster.domain.aggregate.OwnedMonster
 import tamago.server.core.monster.domain.enum.AssetType
 import tamago.server.core.monster.domain.port.inbound.query.CreateMonsterAssetQueryDto
 import tamago.server.core.monster.domain.port.inbound.query.InitMonsterQueryDto
@@ -26,18 +28,26 @@ class MonsterFacade(
     @Transactional(readOnly = true)
     fun getMonsterDex(userId: UserId): List<MonsterDexQueryDto> {
         // 1단계 몬스터와 해금 조건 함께 조회
-        val monsters = monsterQueryService.getAllFirstStageWithUnlockPolicies()
+        val firstStageMonsters = monsterQueryService.getAllFirstStageWithUnlockPolicies()
         // 내가 소유한 몬스터 조회
-        val ownedMonsterMap =
-            monsterQueryService
-                .getOwnedMonstersByUserId(userId)
-                .associateBy { it.monsterId }
+        val ownedMonsters = monsterQueryService.getOwnedMonstersByUserId(userId)
 
-        return monsters.map { monster ->
-            // 내가 소유한 몬스터인지 확인
-            val ownedMonster = ownedMonsterMap[monster.id]
+        // 소유 몬스터의 진화 체인을 역추적하여 1단계 몬스터 ID로 매핑
+        val ownedByRootId = mutableMapOf<MonsterId, Pair<OwnedMonster, Monster>>()
+        for (owned in ownedMonsters) {
+            val chain = monsterQueryService.getEvolutionChain(owned.monsterId)
+            val root = chain.first()
+            val current = chain.first { it.id == owned.monsterId }
+            ownedByRootId[root.id!!] = owned to current
+        }
 
-            MonsterDexQueryDto.of(monster, ownedMonster)
+        return firstStageMonsters.map { baseMonster ->
+            val entry = ownedByRootId[baseMonster.id]
+            MonsterDexQueryDto.of(
+                baseMonster = baseMonster,
+                currentMonster = entry?.second,
+                ownedMonster = entry?.first,
+            )
         }
     }
 

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterAssetNotFoundException.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterAssetNotFoundException.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.monster.application.exception
+
+import tamago.server.core.common.exception.BusinessException
+
+class MonsterAssetNotFoundException :
+    BusinessException(
+        MonsterExceptionCode.MONSTER_ASSET_NOT_FOUND,
+    )

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterExceptionCode.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/exception/MonsterExceptionCode.kt
@@ -12,6 +12,7 @@ enum class MonsterExceptionCode(
     OWNED_MONSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MONSTER_4041", "소유한 몬스터를 찾을 수 없습니다."),
     MONSTER_ASSET_ALREADY_EXISTS(HttpStatus.CONFLICT, "MONSTER_4090", "해당 몬스터의 에셋이 이미 존재합니다."),
     MONSTER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "MONSTER_4030", "해당 몬스터에 접근 권한이 없습니다."),
+    MONSTER_ASSET_NOT_FOUND(HttpStatus.NOT_FOUND, "MONSTER_4042", "몬스터 에셋을 찾을 수 없습니다."),
     MONSTER_ALREADY_OWNED(HttpStatus.CONFLICT, "MONSTER_4091", "이미 소유한 몬스터입니다."),
     ;
 

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterCommandService.kt
@@ -77,6 +77,10 @@ class MonsterCommandService(
         ownedMonsterPersistencePort.save(ownedMonster)
     }
 
+    fun hardDeleteMonsterAsset(monsterAsset: MonsterAsset) {
+        monsterAssetPersistencePort.deleteById(monsterAsset)
+    }
+
     fun ownMonster(
         monsterId: MonsterId,
         userId: UserId,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/application/service/MonsterQueryService.kt
@@ -7,6 +7,7 @@ import tamago.server.core.common.vo.UserId
 import tamago.server.core.monster.MonsterQuery
 import tamago.server.core.monster.MonsterQueryUseCase
 import tamago.server.core.monster.application.exception.MonsterAssetAlreadyExistsException
+import tamago.server.core.monster.application.exception.MonsterAssetNotFoundException
 import tamago.server.core.monster.application.exception.MonsterNotFoundException
 import tamago.server.core.monster.application.exception.OwnedMonsterNotFoundException
 import tamago.server.core.monster.domain.aggregate.Monster
@@ -85,6 +86,13 @@ class MonsterQueryService(
         if (firstStageMonsters.isEmpty()) throw MonsterNotFoundException()
         return firstStageMonsters.random()
     }
+
+    fun getMonsterAsset(
+        monsterId: MonsterId,
+        assetType: AssetType,
+    ): MonsterAsset =
+        monsterAssetPersistencePort.findByMonsterIdAndAssetType(monsterId, assetType)
+            ?: throw MonsterAssetNotFoundException()
 
     fun checkMonsterAssetNotExists(
         monsterId: MonsterId,

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/inbound/query/MonsterDexQueryDto.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/inbound/query/MonsterDexQueryDto.kt
@@ -12,16 +12,19 @@ data class MonsterDexQueryDto(
 ) {
     companion object {
         fun of(
-            monster: Monster,
+            baseMonster: Monster,
+            currentMonster: Monster?,
             ownedMonster: OwnedMonster?,
-        ): MonsterDexQueryDto =
-            MonsterDexQueryDto(
-                monsterId = monster.id!!.value,
-                nickname = monster.nickname,
-                unlockDescription = monster.unlockPolicies.firstOrNull()?.description,
+        ): MonsterDexQueryDto {
+            val displayMonster = currentMonster ?: baseMonster
+            return MonsterDexQueryDto(
+                monsterId = displayMonster.id!!.value,
+                nickname = displayMonster.nickname,
+                unlockDescription = baseMonster.unlockPolicies.firstOrNull()?.description,
                 owned = ownedMonster != null,
                 ownedMonster = ownedMonster?.let { OwnedMonsterInfo.of(it) },
             )
+        }
     }
 
     data class OwnedMonsterInfo(

--- a/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/MonsterAssetPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/monster/domain/port/outbound/MonsterAssetPersistencePort.kt
@@ -21,4 +21,11 @@ interface MonsterAssetPersistencePort {
     fun findAll(): List<MonsterAsset>
 
     fun save(monsterAsset: MonsterAsset): MonsterAsset
+
+    fun findByMonsterIdAndAssetType(
+        monsterId: MonsterId,
+        assetType: AssetType,
+    ): MonsterAsset?
+
+    fun deleteById(monsterAsset: MonsterAsset)
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/UserFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/UserFacade.kt
@@ -8,7 +8,6 @@ import tamago.server.core.refreshtoken.RefreshTokenQueryUseCase
 import tamago.server.core.user.application.exception.EmailAlreadyExistsException
 import tamago.server.core.user.application.exception.InvalidCredentialsException
 import tamago.server.core.user.application.exception.UserSaveErrorException
-import tamago.server.core.user.application.exception.UserWithdrawnException
 import tamago.server.core.user.application.service.UserCommandService
 import tamago.server.core.user.application.service.UserQueryService
 import tamago.server.core.user.domain.port.inbound.command.LoginCommandDto
@@ -36,13 +35,17 @@ class UserFacade(
     }
 
     fun socialLogin(command: LoginCommandDto): TokenQueryDto {
-        command
-            .takeUnless { userQueryService.existsDeletedByExternalId(it.provider, it.externalId) }
-            ?: throw UserWithdrawnException()
+        val existingUser = userQueryService.findSocialUser(command.provider, command.externalId)
 
         val user =
-            userQueryService.findByExternalId(command.provider, command.externalId)
-                ?: userCommandService.createSocialUser(command)
+            when {
+                existingUser == null -> userCommandService.createSocialUser(command)
+                existingUser.deletedAt != null -> {
+                    userCommandService.restoreUser(existingUser)
+                    existingUser
+                }
+                else -> existingUser
+            }
 
         val userId = user.id ?: throw UserSaveErrorException()
 

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/application/service/UserQueryService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/application/service/UserQueryService.kt
@@ -31,10 +31,15 @@ class UserQueryService(
             ?: throw InvalidCredentialsException()
     }
 
-    fun findByExternalId(
+    fun findActiveSocialUser(
         provider: AuthProvider,
         externalId: String,
     ): User? = userPersistencePort.findByExternalId(provider, externalId)
+
+    fun findSocialUser(
+        provider: AuthProvider,
+        externalId: String,
+    ): User? = userPersistencePort.findByAuthsProviderAndAuthsExternalId(provider, externalId)
 
     fun findByEmail(email: String): User? = userPersistencePort.findByEmail(email)
 

--- a/tamago-core/src/main/kotlin/tamago/server/core/user/domain/port/outbound/UserPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/user/domain/port/outbound/UserPersistencePort.kt
@@ -14,6 +14,11 @@ interface UserPersistencePort {
         externalId: String,
     ): User?
 
+    fun findByAuthsProviderAndAuthsExternalId(
+        provider: AuthProvider,
+        externalId: String,
+    ): User?
+
     fun findByEmail(email: String): User?
 
     fun existsByEmail(email: String): Boolean

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/monster/v1/controller/MonsterController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -150,6 +151,17 @@ class MonsterController(
                 assetKey = result.assetKey,
             ),
         )
+    }
+
+    @Operation(summary = "\uD83E\uDDEA 몬스터 에셋 삭제", description = "몬스터 에셋을 S3와 DB에서 하드 딜리트합니다.")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/api/v1/monsters/{monsterId}/assets")
+    fun deleteMonsterAsset(
+        @PathVariable monsterId: Long,
+        @RequestParam assetType: AssetType,
+    ): CustomResponse<Void> {
+        monsterFacade.deleteMonsterAsset(MonsterId(monsterId), assetType)
+        return CustomResponse.ok()
     }
 
     @Operation(summary = "\uD83E\uDDEA 몬스터 에셋 직접 업로드", description = "파일을 서버를 통해 직접 S3에 업로드합니다.")

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/monster/repository/MonsterAssetJpaRepository.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/monster/repository/MonsterAssetJpaRepository.kt
@@ -1,7 +1,6 @@
 package tamago.server.storage.monster.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
-import tamago.server.core.monster.domain.enum.AssetType
 import tamago.server.storage.monster.entity.MonsterAssetEntity
 import java.time.LocalDateTime
 
@@ -9,9 +8,4 @@ interface MonsterAssetJpaRepository : JpaRepository<MonsterAssetEntity, Long> {
     fun existsByUpdatedAtAfterAndDeletedAtIsNull(since: LocalDateTime): Boolean
 
     fun findAllByDeletedAtIsNull(): List<MonsterAssetEntity>
-
-    fun findByMonsterIdAndAssetTypeAndDeletedAtIsNull(
-        monsterId: Long,
-        assetType: AssetType,
-    ): MonsterAssetEntity?
 }

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/monster/repository/MonsterAssetJpaRepository.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/monster/repository/MonsterAssetJpaRepository.kt
@@ -1,6 +1,7 @@
 package tamago.server.storage.monster.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import tamago.server.core.monster.domain.enum.AssetType
 import tamago.server.storage.monster.entity.MonsterAssetEntity
 import java.time.LocalDateTime
 
@@ -8,4 +9,9 @@ interface MonsterAssetJpaRepository : JpaRepository<MonsterAssetEntity, Long> {
     fun existsByUpdatedAtAfterAndDeletedAtIsNull(since: LocalDateTime): Boolean
 
     fun findAllByDeletedAtIsNull(): List<MonsterAssetEntity>
+
+    fun findByMonsterIdAndAssetTypeAndDeletedAtIsNull(
+        monsterId: Long,
+        assetType: AssetType,
+    ): MonsterAssetEntity?
 }

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/monster/repository/MonsterAssetPersistenceAdapter.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/monster/repository/MonsterAssetPersistenceAdapter.kt
@@ -13,6 +13,7 @@ import tamago.server.storage.monster.entity.MonsterAssetEntity
 import tamago.server.storage.monster.entity.MonsterEntity
 import tamago.server.storage.monster.mapper.MonsterAssetMapper
 import tamago.server.storage.support.findAll
+import tamago.server.storage.support.findOne
 import java.time.LocalDateTime
 
 @Repository
@@ -96,10 +97,26 @@ class MonsterAssetPersistenceAdapter(
     override fun findByMonsterIdAndAssetType(
         monsterId: MonsterId,
         assetType: AssetType,
-    ): MonsterAsset? =
-        monsterAssetJpaRepository
-            .findByMonsterIdAndAssetTypeAndDeletedAtIsNull(monsterId.value, assetType)
+    ): MonsterAsset? {
+        val query =
+            jpql {
+                select(
+                    entity(MonsterAssetEntity::class),
+                ).from(
+                    entity(MonsterAssetEntity::class),
+                ).where(
+                    and(
+                        path(MonsterAssetEntity::monster)(MonsterEntity::id).eq(monsterId.value),
+                        path(MonsterAssetEntity::assetType).eq(assetType),
+                        path(MonsterAssetEntity::deletedAt).isNull(),
+                    ),
+                )
+            }
+
+        return entityManager
+            .findOne<MonsterAssetEntity>(query, jpqlRenderContext)
             ?.let { MonsterAssetMapper.toDomain(it) }
+    }
 
     override fun deleteById(monsterAsset: MonsterAsset) {
         monsterAssetJpaRepository.deleteById(monsterAsset.id!!.value)

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/monster/repository/MonsterAssetPersistenceAdapter.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/monster/repository/MonsterAssetPersistenceAdapter.kt
@@ -92,4 +92,16 @@ class MonsterAssetPersistenceAdapter(
         val saved = monsterAssetJpaRepository.save(entity)
         return MonsterAssetMapper.toDomain(saved)!!
     }
+
+    override fun findByMonsterIdAndAssetType(
+        monsterId: MonsterId,
+        assetType: AssetType,
+    ): MonsterAsset? =
+        monsterAssetJpaRepository
+            .findByMonsterIdAndAssetTypeAndDeletedAtIsNull(monsterId.value, assetType)
+            ?.let { MonsterAssetMapper.toDomain(it) }
+
+    override fun deleteById(monsterAsset: MonsterAsset) {
+        monsterAssetJpaRepository.deleteById(monsterAsset.id!!.value)
+    }
 }

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/user/repository/UserJpaRepository.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/user/repository/UserJpaRepository.kt
@@ -9,6 +9,11 @@ interface UserJpaRepository : JpaRepository<UserEntity, Long> {
         externalId: String,
     ): UserEntity?
 
+    fun findByAuthsProviderAndAuthsExternalId(
+        provider: String,
+        externalId: String,
+    ): UserEntity?
+
     fun findByAuthsEmail(email: String): UserEntity?
 
     fun existsByAuthsEmail(email: String): Boolean

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/user/repository/UserPersistenceAdapter.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/user/repository/UserPersistenceAdapter.kt
@@ -23,6 +23,14 @@ class UserPersistenceAdapter(
             userJpaRepository.findByAuthsProviderAndAuthsExternalIdAndDeletedAtIsNull(provider.name, externalId),
         )
 
+    override fun findByAuthsProviderAndAuthsExternalId(
+        provider: AuthProvider,
+        externalId: String,
+    ): User? =
+        UserMapper.toDomain(
+            userJpaRepository.findByAuthsProviderAndAuthsExternalId(provider.name, externalId),
+        )
+
     override fun findByEmail(email: String): User? = UserMapper.toDomain(userJpaRepository.findByAuthsEmail(email))
 
     override fun existsByEmail(email: String): Boolean = userJpaRepository.existsByAuthsEmail(email)


### PR DESCRIPTION
## Summary

>- #67 

Opentelemetry 환경변수 값 조정하고 일부 쿼리에 JPA 메서드 쿼리 대신 Kotlin JDSL 사용
<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- Opentelemetry 환경변수 값 조정하여 connection 오류 수정
- GitHub Actions 워크플로에서 Health Check 타임아웃 시간 조정
- 관리자용 몬스터 에셋 삭제 API 추가
- 연관 관계로 인해 자동생성되는 LEFT JOIN JPA 쿼리를 제거하고 Kotlin JDSL로 명시적인 쿼리 작성

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 전용 몬스터 에셋 삭제 API 추가 및 이미지(파일) 삭제 기능 제공
  * 에셋 미발견에 대한 명확한 오류 코드/응답 추가

* **인프라 개선**
  * 배포 헬스체크 재시도 횟수 증가로 배포 안정성 향상
  * 런타임 텔레메트리(로그/메트릭/트레이스) 및 Sentry 자동 초기화 비활성화 설정 추가

* **개선**
  * 소셜 로그인 흐름 개선: 삭제된 계정 복원 및 기존 계정 재사용 처리 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->