### PR TITLE
refactor: 푸시 알림 직접 발송 제거하고 Notification 엔티티 기반 발송 구조로 전환

### DIFF
--- a/tamago-core/src/main/kotlin/tamago/server/core/letter/application/scheduler/UserLetterSender.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/letter/application/scheduler/UserLetterSender.kt
@@ -7,7 +7,6 @@ import tamago.server.core.letter.application.service.LetterQueryService
 import tamago.server.core.letter.application.service.UserLetterCommandService
 import tamago.server.core.letter.application.service.UserLetterQueryService
 import tamago.server.core.notification.NotificationCommandUseCase
-import tamago.server.core.notification.NotificationQueryUseCase
 import tamago.server.core.running.RunningQueryUseCase
 import java.time.LocalDateTime
 
@@ -19,7 +18,6 @@ class UserLetterSender(
     private val userLetterCommandService: UserLetterCommandService,
     private val letterQueryService: LetterQueryService,
     private val runningQueryUseCase: RunningQueryUseCase,
-    private val notificationQueryUseCase: NotificationQueryUseCase,
     private val notificationCommandUseCase: NotificationCommandUseCase,
 ) {
     @Scheduled(fixedDelay = 60_000)
@@ -34,25 +32,20 @@ class UserLetterSender(
         // 편지 상태를 UNREAD로 전환
         userLetterCommandService.sendLetters(scheduledLetters)
 
-        // 유저별로 FCM 알림 발송 (알림 실패가 편지 발송을 막지 않음)
+        // 유저별로 알림 저장 (NotificationSender 스케줄러가 FCM 발송)
         val userIds = scheduledLetters.map { it.userId }.distinct()
         userIds.forEach { userId ->
             try {
-                val tokens = notificationQueryUseCase.getFcmTokensByUserId(userId)
-                if (tokens.isEmpty()) {
-                    logger.info { "FCM 토큰이 없어 알림 발송 생략 - userId: $userId" }
-                    return@forEach
-                }
                 val letterId = scheduledLetters.first { it.userId == userId }.letterId
                 val letter = letterQueryService.get(letterId)
                 val monsterNickname = runningQueryUseCase.getLastMonsterNickname(userId)
-                notificationCommandUseCase.sendLetterArrivalNotification(
-                    tokens = tokens,
+                notificationCommandUseCase.createNotification(
+                    userId = userId,
                     title = monsterNickname?.let { "안녕 난 ${it}이야" } ?: letter.title,
-                    body = letter.content.value,
+                    content = letter.content.value,
                 )
             } catch (e: Exception) {
-                logger.error(e) { "편지 도착 알림 발송 중 오류 발생 - userId: $userId" }
+                logger.error(e) { "편지 도착 알림 저장 중 오류 발생 - userId: $userId" }
             }
         }
     }

--- a/tamago-core/src/main/kotlin/tamago/server/core/notification/NotificationCommandUseCase.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/notification/NotificationCommandUseCase.kt
@@ -1,9 +1,11 @@
 package tamago.server.core.notification
 
+import tamago.server.core.common.vo.UserId
+
 interface NotificationCommandUseCase {
-    fun sendLetterArrivalNotification(
-        tokens: List<String>,
+    fun createNotification(
+        userId: UserId,
         title: String,
-        body: String,
+        content: String,
     )
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/notification/NotificationFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/notification/NotificationFacade.kt
@@ -2,6 +2,7 @@ package tamago.server.core.notification
 
 import org.springframework.stereotype.Component
 import tamago.server.core.common.vo.UserId
+import tamago.server.core.notification.application.exception.FcmTokenNotFoundException
 import tamago.server.core.notification.application.service.NotificationCommandService
 import tamago.server.core.notification.application.service.NotificationQueryService
 import tamago.server.core.notification.domain.aggregate.FcmToken
@@ -28,5 +29,15 @@ class NotificationFacade(
 
     fun deleteFcmTokensByUserId(userId: UserId) {
         notificationCommandService.deleteFcmTokensByUserId(userId)
+    }
+
+    fun sendTestNotification(userId: UserId) {
+        val tokens = notificationQueryService.getFcmTokensByUserId(userId)
+        if (tokens.isEmpty()) throw FcmTokenNotFoundException()
+        notificationCommandService.sendLetterArrivalNotification(
+            tokens = tokens,
+            title = "테스트 알림",
+            body = "푸시 알림 테스트입니다.",
+        )
     }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/notification/NotificationFacade.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/notification/NotificationFacade.kt
@@ -2,7 +2,6 @@ package tamago.server.core.notification
 
 import org.springframework.stereotype.Component
 import tamago.server.core.common.vo.UserId
-import tamago.server.core.notification.application.exception.FcmTokenNotFoundException
 import tamago.server.core.notification.application.service.NotificationCommandService
 import tamago.server.core.notification.application.service.NotificationQueryService
 import tamago.server.core.notification.domain.aggregate.FcmToken
@@ -32,12 +31,10 @@ class NotificationFacade(
     }
 
     fun sendTestNotification(userId: UserId) {
-        val tokens = notificationQueryService.getFcmTokensByUserId(userId)
-        if (tokens.isEmpty()) throw FcmTokenNotFoundException()
-        notificationCommandService.sendLetterArrivalNotification(
-            tokens = tokens,
+        notificationCommandService.createNotification(
+            userId = userId,
             title = "테스트 알림",
-            body = "푸시 알림 테스트입니다.",
+            content = "푸시 알림 테스트입니다.",
         )
     }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/notification/application/exception/FcmTokenNotFoundException.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/notification/application/exception/FcmTokenNotFoundException.kt
@@ -1,0 +1,8 @@
+package tamago.server.core.notification.application.exception
+
+import tamago.server.core.common.exception.BusinessException
+
+class FcmTokenNotFoundException :
+    BusinessException(
+        NotificationExceptionCode.FCM_TOKEN_NOT_FOUND,
+    )

--- a/tamago-core/src/main/kotlin/tamago/server/core/notification/application/exception/NotificationExceptionCode.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/notification/application/exception/NotificationExceptionCode.kt
@@ -1,0 +1,19 @@
+package tamago.server.core.notification.application.exception
+
+import org.springframework.http.HttpStatus
+import tamago.server.core.common.exception.ExceptionCode
+
+enum class NotificationExceptionCode(
+    @JvmField val status: HttpStatus,
+    @JvmField val code: String,
+    @JvmField val message: String,
+) : ExceptionCode {
+    FCM_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_4040", "등록된 FCM 토큰이 없습니다."),
+    ;
+
+    override fun getStatus(): HttpStatus = status
+
+    override fun getCode(): String = code
+
+    override fun getMessage(): String = message
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/notification/application/scheduler/NotificationSender.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/notification/application/scheduler/NotificationSender.kt
@@ -1,0 +1,26 @@
+package tamago.server.core.notification.application.scheduler
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import tamago.server.core.notification.application.service.NotificationCommandService
+import tamago.server.core.notification.domain.port.outbound.NotificationPersistencePort
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class NotificationSender(
+    private val notificationPersistencePort: NotificationPersistencePort,
+    private val notificationCommandService: NotificationCommandService,
+) {
+    @Scheduled(fixedDelay = 60_000)
+    fun sendPendingNotifications() {
+        val pendingNotifications = notificationPersistencePort.findAllPending()
+
+        if (pendingNotifications.isEmpty()) return
+
+        logger.info { "발송 대기 알림 ${pendingNotifications.size}건 발견" }
+
+        notificationCommandService.sendNotifications(pendingNotifications)
+    }
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/notification/application/service/NotificationCommandService.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/notification/application/service/NotificationCommandService.kt
@@ -6,8 +6,10 @@ import org.springframework.transaction.annotation.Transactional
 import tamago.server.core.common.vo.UserId
 import tamago.server.core.notification.NotificationCommandUseCase
 import tamago.server.core.notification.domain.aggregate.FcmToken
+import tamago.server.core.notification.domain.aggregate.Notification
 import tamago.server.core.notification.domain.port.outbound.FcmSendPort
 import tamago.server.core.notification.domain.port.outbound.FcmTokenPersistencePort
+import tamago.server.core.notification.domain.port.outbound.NotificationPersistencePort
 
 private val logger = KotlinLogging.logger {}
 
@@ -15,24 +17,51 @@ private val logger = KotlinLogging.logger {}
 @Transactional
 class NotificationCommandService(
     private val fcmTokenPersistencePort: FcmTokenPersistencePort,
+    private val notificationPersistencePort: NotificationPersistencePort,
     private val fcmSendPort: FcmSendPort,
 ) : NotificationCommandUseCase {
     fun save(fcmToken: FcmToken) {
         fcmTokenPersistencePort.save(fcmToken)
     }
 
-    override fun sendLetterArrivalNotification(
-        tokens: List<String>,
+    override fun createNotification(
+        userId: UserId,
         title: String,
-        body: String,
+        content: String,
     ) {
-        fcmSendPort.send(
-            tokens = tokens,
-            title = title,
-            body = body,
-            destination = null,
-        )
-        logger.info { "편지 도착 알림 발송 완료 - tokenCount: ${tokens.size}" }
+        val notification = Notification.create(userId = userId, title = title, content = content)
+        notificationPersistencePort.save(notification)
+        logger.info { "알림 저장 완료 - userId: $userId" }
+    }
+
+    fun sendNotifications(notifications: List<Notification>) {
+        notifications
+            .groupBy { it.userId }
+            .forEach { (userId, userNotifications) ->
+                try {
+                    val tokens =
+                        fcmTokenPersistencePort
+                            .findAllByUserId(userId)
+                            .mapNotNull { it.token }
+                    if (tokens.isEmpty()) {
+                        logger.info { "FCM 토큰이 없어 알림 발송 생략 - userId: $userId" }
+                        return@forEach
+                    }
+                    userNotifications.forEach { notification ->
+                        fcmSendPort.send(
+                            tokens = tokens,
+                            title = notification.title,
+                            body = notification.content ?: "",
+                            destination = null,
+                        )
+                        notification.markAsSent()
+                        notificationPersistencePort.save(notification)
+                    }
+                    logger.info { "알림 발송 완료 - userId: $userId, count: ${userNotifications.size}" }
+                } catch (e: Exception) {
+                    logger.error(e) { "알림 발송 중 오류 발생 - userId: $userId" }
+                }
+            }
     }
 
     fun deleteFcmTokensByUserId(userId: UserId) {

--- a/tamago-core/src/main/kotlin/tamago/server/core/notification/domain/aggregate/Notification.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/notification/domain/aggregate/Notification.kt
@@ -11,7 +11,6 @@ class Notification(
     val content: String? = null,
     status: NotificationStatus = NotificationStatus.PENDING,
     val userId: UserId,
-    val scheduledAt: LocalDateTime? = null,
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null,
     val deletedAt: LocalDateTime? = null,
@@ -32,14 +31,12 @@ class Notification(
             userId: UserId,
             title: String,
             content: String,
-            scheduledAt: LocalDateTime? = null,
         ): Notification =
             Notification(
                 userId = userId,
                 title = title,
                 content = content,
                 status = NotificationStatus.PENDING,
-                scheduledAt = scheduledAt,
             )
     }
 }

--- a/tamago-core/src/main/kotlin/tamago/server/core/notification/domain/aggregate/Notification.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/notification/domain/aggregate/Notification.kt
@@ -1,6 +1,7 @@
 package tamago.server.core.notification.domain.aggregate
 
 import tamago.server.core.common.vo.UserId
+import tamago.server.core.notification.domain.enum.NotificationStatus
 import tamago.server.core.notification.domain.vo.NotificationId
 import java.time.LocalDateTime
 
@@ -8,21 +9,23 @@ class Notification(
     val id: NotificationId? = null,
     val title: String? = null,
     val content: String? = null,
-    isRead: Boolean = false,
+    status: NotificationStatus = NotificationStatus.PENDING,
     val userId: UserId,
     val scheduledAt: LocalDateTime? = null,
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null,
     val deletedAt: LocalDateTime? = null,
 ) {
-    var isRead: Boolean = isRead
+    var status: NotificationStatus = status
         private set
 
-    fun markAsRead() {
-        this.isRead = true
+    fun markAsSent() {
+        this.status = NotificationStatus.SENT
     }
 
-    fun isScheduled(): Boolean = scheduledAt != null
+    fun markAsRead() {
+        this.status = NotificationStatus.READ
+    }
 
     companion object {
         fun create(
@@ -35,7 +38,7 @@ class Notification(
                 userId = userId,
                 title = title,
                 content = content,
-                isRead = false,
+                status = NotificationStatus.PENDING,
                 scheduledAt = scheduledAt,
             )
     }

--- a/tamago-core/src/main/kotlin/tamago/server/core/notification/domain/enum/NotificationStatus.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/notification/domain/enum/NotificationStatus.kt
@@ -1,0 +1,7 @@
+package tamago.server.core.notification.domain.enum
+
+enum class NotificationStatus {
+    PENDING,
+    SENT,
+    READ,
+}

--- a/tamago-core/src/main/kotlin/tamago/server/core/notification/domain/port/outbound/NotificationPersistencePort.kt
+++ b/tamago-core/src/main/kotlin/tamago/server/core/notification/domain/port/outbound/NotificationPersistencePort.kt
@@ -1,0 +1,9 @@
+package tamago.server.core.notification.domain.port.outbound
+
+import tamago.server.core.notification.domain.aggregate.Notification
+
+interface NotificationPersistencePort {
+    fun save(notification: Notification): Notification
+
+    fun findAllPending(): List<Notification>
+}

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/notification/v1/controller/NotificationController.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/notification/v1/controller/NotificationController.kt
@@ -15,6 +15,7 @@ import tamago.server.core.user.domain.aggregate.User
 import tamago.server.gateway.common.annotation.CurrentUser
 import tamago.server.gateway.common.response.CustomResponse
 import tamago.server.gateway.presentation.notification.v1.request.FcmTokenRequest
+import tamago.server.gateway.presentation.notification.v1.request.TestNotificationRequest
 
 @Tag(name = "Notification API", description = "푸시 알림 관련 API")
 @RestController
@@ -36,6 +37,16 @@ class NotificationController(
                 token = request.token,
             )
         notificationFacade.registerFcmToken(command)
+        return CustomResponse.ok()
+    }
+
+    @Operation(summary = "\uD83E\uDDEA 푸시 알림 테스트", description = "특정 유저에게 테스트 푸시 알림을 발송합니다.")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/api/v1/fcm/test")
+    fun sendTestNotification(
+        @Valid @RequestBody request: TestNotificationRequest,
+    ): CustomResponse<Void> {
+        notificationFacade.sendTestNotification(UserId(request.userId))
         return CustomResponse.ok()
     }
 }

--- a/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/notification/v1/request/TestNotificationRequest.kt
+++ b/tamago-gateway/src/main/kotlin/tamago/server/gateway/presentation/notification/v1/request/TestNotificationRequest.kt
@@ -1,0 +1,10 @@
+package tamago.server.gateway.presentation.notification.v1.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+data class TestNotificationRequest(
+    @field:Schema(description = "알림을 보낼 유저 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @field:NotNull(message = "유저 ID는 필수입니다.")
+    val userId: Long,
+)

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/notification/entity/NotificationEntity.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/notification/entity/NotificationEntity.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import tamago.server.core.notification.domain.enum.NotificationStatus
 import tamago.server.storage.support.BaseTimeEntity
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "t_notifications")
@@ -26,6 +25,4 @@ class NotificationEntity(
     var status: NotificationStatus = NotificationStatus.PENDING,
     @Column(name = "user_id", nullable = false)
     val userId: Long,
-    @Column(name = "scheduled_at")
-    val scheduledAt: LocalDateTime? = null,
 ) : BaseTimeEntity()

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/notification/entity/NotificationEntity.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/notification/entity/NotificationEntity.kt
@@ -2,10 +2,13 @@ package tamago.server.storage.notification.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import tamago.server.core.notification.domain.enum.NotificationStatus
 import tamago.server.storage.support.BaseTimeEntity
 import java.time.LocalDateTime
 
@@ -18,8 +21,9 @@ class NotificationEntity(
     val id: Long? = null,
     val title: String? = null,
     val content: String? = null,
-    @Column(name = "is_read")
-    var isRead: Boolean = false,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: NotificationStatus = NotificationStatus.PENDING,
     @Column(name = "user_id", nullable = false)
     val userId: Long,
     @Column(name = "scheduled_at")

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/notification/mapper/NotificationMapper.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/notification/mapper/NotificationMapper.kt
@@ -11,7 +11,7 @@ object NotificationMapper {
             id = notification.id?.value,
             title = notification.title,
             content = notification.content,
-            isRead = notification.isRead,
+            status = notification.status,
             userId = notification.userId.value,
             scheduledAt = notification.scheduledAt,
         )
@@ -23,7 +23,7 @@ object NotificationMapper {
             id = entity.id?.let { NotificationId(it) },
             title = entity.title,
             content = entity.content,
-            isRead = entity.isRead,
+            status = entity.status,
             userId = UserId(entity.userId),
             scheduledAt = entity.scheduledAt,
             createdAt = entity.createdAt,

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/notification/mapper/NotificationMapper.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/notification/mapper/NotificationMapper.kt
@@ -13,7 +13,6 @@ object NotificationMapper {
             content = notification.content,
             status = notification.status,
             userId = notification.userId.value,
-            scheduledAt = notification.scheduledAt,
         )
 
     fun toDomain(entity: NotificationEntity?): Notification? {
@@ -25,7 +24,6 @@ object NotificationMapper {
             content = entity.content,
             status = entity.status,
             userId = UserId(entity.userId),
-            scheduledAt = entity.scheduledAt,
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt,
             deletedAt = entity.deletedAt,

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/notification/repository/NotificationJpaRepository.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/notification/repository/NotificationJpaRepository.kt
@@ -1,0 +1,9 @@
+package tamago.server.storage.notification.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import tamago.server.core.notification.domain.enum.NotificationStatus
+import tamago.server.storage.notification.entity.NotificationEntity
+
+interface NotificationJpaRepository : JpaRepository<NotificationEntity, Long> {
+    fun findAllByStatusAndDeletedAtIsNull(status: NotificationStatus): List<NotificationEntity>
+}

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/notification/repository/NotificationJpaRepository.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/notification/repository/NotificationJpaRepository.kt
@@ -1,9 +1,9 @@
 package tamago.server.storage.notification.repository
 
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import org.springframework.data.jpa.repository.JpaRepository
-import tamago.server.core.notification.domain.enum.NotificationStatus
 import tamago.server.storage.notification.entity.NotificationEntity
 
-interface NotificationJpaRepository : JpaRepository<NotificationEntity, Long> {
-    fun findAllByStatusAndDeletedAtIsNull(status: NotificationStatus): List<NotificationEntity>
-}
+interface NotificationJpaRepository :
+    JpaRepository<NotificationEntity, Long>,
+    KotlinJdslJpqlExecutor

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/notification/repository/NotificationPersistenceAdapter.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/notification/repository/NotificationPersistenceAdapter.kt
@@ -1,0 +1,23 @@
+package tamago.server.storage.notification.repository
+
+import org.springframework.stereotype.Repository
+import tamago.server.core.notification.domain.aggregate.Notification
+import tamago.server.core.notification.domain.enum.NotificationStatus
+import tamago.server.core.notification.domain.port.outbound.NotificationPersistencePort
+import tamago.server.storage.notification.mapper.NotificationMapper
+
+@Repository
+class NotificationPersistenceAdapter(
+    private val notificationJpaRepository: NotificationJpaRepository,
+) : NotificationPersistencePort {
+    override fun save(notification: Notification): Notification {
+        val entity = NotificationMapper.toEntity(notification)
+        val saved = notificationJpaRepository.save(entity)
+        return NotificationMapper.toDomain(saved)!!
+    }
+
+    override fun findAllPending(): List<Notification> =
+        notificationJpaRepository
+            .findAllByStatusAndDeletedAtIsNull(NotificationStatus.PENDING)
+            .mapNotNull { NotificationMapper.toDomain(it) }
+}

--- a/tamago-storage/src/main/kotlin/tamago/server/storage/notification/repository/NotificationPersistenceAdapter.kt
+++ b/tamago-storage/src/main/kotlin/tamago/server/storage/notification/repository/NotificationPersistenceAdapter.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Repository
 import tamago.server.core.notification.domain.aggregate.Notification
 import tamago.server.core.notification.domain.enum.NotificationStatus
 import tamago.server.core.notification.domain.port.outbound.NotificationPersistencePort
+import tamago.server.storage.notification.entity.NotificationEntity
 import tamago.server.storage.notification.mapper.NotificationMapper
 
 @Repository
@@ -18,6 +19,15 @@ class NotificationPersistenceAdapter(
 
     override fun findAllPending(): List<Notification> =
         notificationJpaRepository
-            .findAllByStatusAndDeletedAtIsNull(NotificationStatus.PENDING)
+            .findAll {
+                select(entity(NotificationEntity::class))
+                    .from(entity(NotificationEntity::class))
+                    .where(
+                        and(
+                            path(NotificationEntity::status).equal(NotificationStatus.PENDING),
+                            path(NotificationEntity::deletedAt).isNull(),
+                        ),
+                    )
+            }.filterNotNull()
             .mapNotNull { NotificationMapper.toDomain(it) }
 }

--- a/tamago-storage/src/main/resources/db/migration/V27__add_is_sent_to_notifications.sql
+++ b/tamago-storage/src/main/resources/db/migration/V27__add_is_sent_to_notifications.sql
@@ -1,2 +1,3 @@
 ALTER TABLE t_notifications DROP COLUMN is_read;
+ALTER TABLE t_notifications DROP COLUMN scheduled_at;
 ALTER TABLE t_notifications ADD COLUMN status ENUM('PENDING', 'SENT', 'READ') NOT NULL DEFAULT 'PENDING';

--- a/tamago-storage/src/main/resources/db/migration/V27__add_is_sent_to_notifications.sql
+++ b/tamago-storage/src/main/resources/db/migration/V27__add_is_sent_to_notifications.sql
@@ -1,0 +1,2 @@
+ALTER TABLE t_notifications DROP COLUMN is_read;
+ALTER TABLE t_notifications ADD COLUMN status ENUM('PENDING', 'SENT', 'READ') NOT NULL DEFAULT 'PENDING';


### PR DESCRIPTION
## Summary

>- #69 

푸시 알림 직접 발송 제거하고 Notification 엔티티 기반 발송 구조로 전환

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 푸시 알림 테스트 할 수 있는 관리자용 API 추가
- 푸시 알림 직접 발송 제거하고 Notification 엔티티 기반 발송 구조로 전환

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자가 특정 사용자에게 테스트 푸시 알림을 보낼 수 있는 API가 추가되었습니다.

* **Refactor**
  * 알림은 이제 먼저 저장된 뒤 별도 스케줄러에서 배포되어 전송 안정성이 향상되었습니다.
  * 알림 상태가 명확한 단계(PENDING, SENT, READ)로 관리되어 상태 추적이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->